### PR TITLE
Add localized static routing

### DIFF
--- a/accommodation.html
+++ b/accommodation.html
@@ -122,6 +122,7 @@
           <li><a href="/partners" data-i18n-key="nav-partners">Pro partnery</a></li>
           <li><a href="/about" data-i18n-key="nav-about">O nás</a></li>
           <li><a href="/blog" data-i18n-key="nav-blog">Blog</a></li>
+          <li><a href="/faq" data-i18n-key="nav-faq">FAQ</a></li>
           <li><a href="/#contact" data-i18n-key="nav-contact">Kontakt</a></li>
         </ul>
 

--- a/events.html
+++ b/events.html
@@ -4,7 +4,70 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title data-i18n-key="events-page-title">Události a vstupenky na koncerty, festivaly a sport | AJSEE</title>
+  <style id="ajsee-header-boot-stability">
+    html:not(.ajsee-header-ready) .site-header,
+    html:not(.ajsee-header-ready) .site-header * {
+      transition: none !important;
+      animation: none !important;
+    }
+  </style>
+  <script id="ajsee-header-ready-script">
+    (function () {
+      try {
+        requestAnimationFrame(function () {
+          requestAnimationFrame(function () {
+            document.documentElement.classList.add('ajsee-header-ready');
+          });
+        });
+      } catch (e) {
+        document.documentElement.classList.add('ajsee-header-ready');
+      }
+    })();
+  </script>
+
+
+
+  <script id="ajsee-lang-bootstrap">
+    (function () {
+      try {
+        var supported = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+        var url = new URL(window.location.href);
+        var queryLang = (url.searchParams.get('lang') || url.searchParams.get('locale') || url.searchParams.get('hl') || '').toLowerCase().slice(0, 2);
+        var pathMatch = url.pathname.match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+        var pathLang = pathMatch ? pathMatch[1].toLowerCase().slice(0, 2) : '';
+        var lang = supported.indexOf(queryLang) >= 0 ? queryLang : (supported.indexOf(pathLang) >= 0 ? pathLang : 'cs');
+
+        function stripPrefix(pathname) {
+          var clean = String(pathname || '/').replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+          if (!clean) clean = '/';
+          if (clean.charAt(0) !== '/') clean = '/' + clean;
+          clean = clean.replace(/\/index\.html$/i, '/').replace(/\.html$/i, '');
+          if (clean !== '/' && clean.charAt(clean.length - 1) !== '/') clean += '/';
+          return clean;
+        }
+
+        function localizedPath(pathname, targetLang) {
+          var clean = stripPrefix(pathname);
+          return targetLang === 'cs' ? clean : '/' + targetLang + (clean === '/' ? '/' : clean);
+        }
+
+        if (queryLang && supported.indexOf(queryLang) >= 0) {
+          url.searchParams.delete('lang');
+          url.searchParams.delete('locale');
+          url.searchParams.delete('hl');
+          url.pathname = localizedPath(url.pathname, queryLang);
+          window.location.replace(url.pathname + (url.search || '') + (url.hash || ''));
+          return;
+        }
+
+        document.documentElement.lang = lang;
+        document.documentElement.classList.add('lang-' + lang);
+        // Header texty už neschováváme: /en/ stránky jsou generované jako lokalizované HTML.
+
+      } catch (e) {}
+    })();
+  </script>
+<title data-i18n-key="events-page-title">Události a vstupenky na koncerty, festivaly a sport | AJSEE</title>
   <meta
     name="description"
     content="Najdi koncerty, festivaly, sportovní události a další zážitky z celého světa. AJSEE ti pomůže objevovat akce, vstupenky a možnosti cestování přehledně na jednom místě."

--- a/index.html
+++ b/index.html
@@ -4,7 +4,70 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title data-i18n-key="seo.home.title">Vstupenky na koncerty, festivaly a sport | AJSEE</title>
+  <style id="ajsee-header-boot-stability">
+    html:not(.ajsee-header-ready) .site-header,
+    html:not(.ajsee-header-ready) .site-header * {
+      transition: none !important;
+      animation: none !important;
+    }
+  </style>
+  <script id="ajsee-header-ready-script">
+    (function () {
+      try {
+        requestAnimationFrame(function () {
+          requestAnimationFrame(function () {
+            document.documentElement.classList.add('ajsee-header-ready');
+          });
+        });
+      } catch (e) {
+        document.documentElement.classList.add('ajsee-header-ready');
+      }
+    })();
+  </script>
+
+
+
+  <script id="ajsee-lang-bootstrap">
+    (function () {
+      try {
+        var supported = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+        var url = new URL(window.location.href);
+        var queryLang = (url.searchParams.get('lang') || url.searchParams.get('locale') || url.searchParams.get('hl') || '').toLowerCase().slice(0, 2);
+        var pathMatch = url.pathname.match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+        var pathLang = pathMatch ? pathMatch[1].toLowerCase().slice(0, 2) : '';
+        var lang = supported.indexOf(queryLang) >= 0 ? queryLang : (supported.indexOf(pathLang) >= 0 ? pathLang : 'cs');
+
+        function stripPrefix(pathname) {
+          var clean = String(pathname || '/').replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+          if (!clean) clean = '/';
+          if (clean.charAt(0) !== '/') clean = '/' + clean;
+          clean = clean.replace(/\/index\.html$/i, '/').replace(/\.html$/i, '');
+          if (clean !== '/' && clean.charAt(clean.length - 1) !== '/') clean += '/';
+          return clean;
+        }
+
+        function localizedPath(pathname, targetLang) {
+          var clean = stripPrefix(pathname);
+          return targetLang === 'cs' ? clean : '/' + targetLang + (clean === '/' ? '/' : clean);
+        }
+
+        if (queryLang && supported.indexOf(queryLang) >= 0) {
+          url.searchParams.delete('lang');
+          url.searchParams.delete('locale');
+          url.searchParams.delete('hl');
+          url.pathname = localizedPath(url.pathname, queryLang);
+          window.location.replace(url.pathname + (url.search || '') + (url.hash || ''));
+          return;
+        }
+
+        document.documentElement.lang = lang;
+        document.documentElement.classList.add('lang-' + lang);
+        // Header texty už neschováváme: /en/ stránky jsou generované jako lokalizované HTML.
+
+      } catch (e) {}
+    })();
+  </script>
+<title data-i18n-key="seo.home.title">Vstupenky na koncerty, festivaly a sport | AJSEE</title>
   <meta
     name="description"
     data-i18n-content="seo.home.description"
@@ -114,25 +177,19 @@
     return homeAppPromise;
   };
 
-  const getInitialLang = () => {
+  
+const getInitialLang = () => {
     try {
+      const supported = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
       const fromUrl = new URLSearchParams(window.location.search).get('lang');
-      if (fromUrl) return fromUrl.toLowerCase().slice(0, 2);
+      const pathMatch = window.location.pathname.match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+      const fromPath = pathMatch ? pathMatch[1] : '';
 
-      const fromCookie = document.cookie
-        .split('; ')
-        .find((item) => item.startsWith('aj_lang='))
-        ?.split('=')[1];
-
-      if (fromCookie) return decodeURIComponent(fromCookie).toLowerCase().slice(0, 2);
-
-      const fromStorage = window.localStorage.getItem('ajsee.lang');
-      if (fromStorage) return fromStorage.toLowerCase().slice(0, 2);
+      const lang = String(fromUrl || fromPath || 'cs').toLowerCase().slice(0, 2);
+      return supported.includes(lang) ? lang : 'cs';
     } catch {
-      // Homepage keeps static CS fallback content.
+      return 'cs';
     }
-
-    return 'cs';
   };
 
   const hasStatefulUrl =
@@ -188,7 +245,10 @@
         var match = document.cookie.match(/(?:^|;\s*)aj_lang=([^;]+)/);
         if (match) fromCookie = decodeURIComponent(match[1] || '');
 
-        var lang = String(fromUrl || fromStorage || fromCookie || 'cs')
+        var pathMatch = window.location.pathname.match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+        var fromPath = pathMatch ? pathMatch[1] : '';
+
+        var lang = String(fromUrl || fromPath || 'cs')
           .toLowerCase()
           .slice(0, 2);
 
@@ -227,6 +287,7 @@
         <li><a href="/partners" data-i18n-key="nav-partners">Pro partnery</a></li>
         <li><a href="/about" data-i18n-key="nav-about">O nás</a></li>
         <li><a href="/blog" data-i18n-key="nav-blog">Blog</a></li>
+                <li><a href="/faq" data-i18n-key="nav-faq">FAQ</a></li>
         <li><a href="#contact" data-i18n-key="nav-contact">Kontakt</a></li>
       </ul>
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:ntl": "netlify dev",
     "start": "npm run dev",
     "prebuild": "npx cpy-cli src/locales/*.json public/locales --parents && npm run svgo:mg && npm run mg:build && npm run mg:copy-json && npm run blog:build",
-    "build": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite build",
+    "build": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite build && node scripts/build-localized-pages.cjs",
     "preview": "vite preview",
     "webpack:dev": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api webpack serve --mode development",
     "webpack:build": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api webpack --mode production",

--- a/scripts/build-localized-pages.cjs
+++ b/scripts/build-localized-pages.cjs
@@ -101,6 +101,11 @@ function escapeAttr(value) {
   return escapeText(value).replace(/"/g, '&quot;');
 }
 
+function writeHtmlFile(file, html) {
+  ensureDir(path.dirname(file));
+  fs.writeFileSync(file, html, 'utf8');
+}
+
 function ensureDir(dir) {
   fs.mkdirSync(dir, { recursive: true });
 }
@@ -529,8 +534,16 @@ function main() {
 
   for (const page of pages) {
     const csHtml = processPage(page.html, page.file, 'cs');
-    fs.writeFileSync(page.file, csHtml, 'utf8');
+
+    writeHtmlFile(page.file, csHtml);
     written++;
+
+    const csPrettyTarget = targetFileForRoute(page.route, 'cs');
+
+    if (path.resolve(csPrettyTarget) !== path.resolve(page.file)) {
+      writeHtmlFile(csPrettyTarget, csHtml);
+      written++;
+    }
 
     for (const lang of PREFIXED_LANGS) {
       const localizedHtml = processPage(page.html, page.file, lang);

--- a/scripts/build-localized-pages.cjs
+++ b/scripts/build-localized-pages.cjs
@@ -1,0 +1,535 @@
+﻿const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const DIST = path.join(ROOT, 'dist');
+const ORIGIN = 'https://ajsee.cz';
+
+const LANGS = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+const PREFIXED_LANGS = LANGS.filter((lang) => lang !== 'cs');
+const CS_NO_TRAILING_CANONICAL_ROUTES = new Set([
+  '/events/',
+  '/accommodation/',
+  '/partners/',
+  '/about/',
+  '/blog/',
+  '/faq/',
+  '/privacy-policy/',
+  '/cookies-policy/'
+]);
+
+const LANG_META = {
+  cs: { label: 'Čeština', flag: '/images/flags/cz.svg' },
+  en: { label: 'English', flag: '/images/flags/gb.svg' },
+  de: { label: 'Deutsch', flag: '/images/flags/de.svg' },
+  sk: { label: 'Slovenčina', flag: '/images/flags/sk.svg' },
+  pl: { label: 'Polski', flag: '/images/flags/pl.svg' },
+  hu: { label: 'Magyar', flag: '/images/flags/hu.svg' }
+};
+
+const BLOG_READMORE_LABELS = {
+  cs: 'Číst dál',
+  en: 'Read more',
+  de: 'Weiterlesen',
+  sk: 'Čítať ďalej',
+  pl: 'Czytaj dalej',
+  hu: 'Tovább olvasom'
+};
+
+const SKIPPED_HTML_FILES = new Set([
+  'test-ticketmaster.html',
+  'ticketmaster-test.html',
+  'admin/index.html',
+  'public/admin/index.html'
+]);
+
+function readJson(file, fallback = {}) {
+  try {
+    return fs.existsSync(file) ? JSON.parse(fs.readFileSync(file, 'utf8')) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function deepMerge(a = {}, b = {}) {
+  const out = { ...a };
+
+  for (const [key, value] of Object.entries(b || {})) {
+    out[key] =
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? deepMerge(out[key] || {}, value)
+        : value;
+  }
+
+  return out;
+}
+
+function getByPath(obj, key) {
+  return String(key || '')
+    .split('.')
+    .reduce((acc, part) => {
+      if (!acc || typeof acc !== 'object') return undefined;
+      return Object.prototype.hasOwnProperty.call(acc, part) ? acc[part] : undefined;
+    }, obj);
+}
+
+function t(dict, key) {
+  const parts = String(key || '')
+    .split('|')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  for (const part of parts) {
+    const value = getByPath(dict, part) ?? dict[part];
+
+    if (value !== undefined && value !== null && String(value).trim() !== '') {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function escapeText(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function escapeAttr(value) {
+  return escapeText(value).replace(/"/g, '&quot;');
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function shouldSkipHtml(rel) {
+  const normalized = String(rel || '').replace(/\\/g, '/');
+
+  if (SKIPPED_HTML_FILES.has(normalized)) return true;
+
+  if (normalized.startsWith('admin/')) return true;
+  if (normalized.startsWith('public/admin/')) return true;
+
+  return false;
+}
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+
+  for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, item.name);
+    const rel = path.relative(DIST, full).replace(/\\/g, '/');
+
+    if (item.isDirectory()) {
+      const first = rel.split('/')[0];
+
+      if (PREFIXED_LANGS.includes(first)) continue;
+      if (rel === 'assets' || rel === 'locales') continue;
+      if (rel === 'admin' || rel.startsWith('admin/')) continue;
+      if (rel === 'public/admin' || rel.startsWith('public/admin/')) continue;
+
+      walk(full, out);
+      continue;
+    }
+
+    if (!item.isFile() || !item.name.endsWith('.html')) continue;
+    if (shouldSkipHtml(rel)) continue;
+
+    out.push(full);
+  }
+
+  return out;
+}
+
+function cleanRouteFromDistFile(file) {
+  const rel = path.relative(DIST, file).replace(/\\/g, '/');
+
+  if (rel === 'index.html') return '/';
+
+  if (rel.endsWith('/index.html')) {
+    return '/' + rel.replace(/\/index\.html$/i, '/');
+  }
+
+  return '/' + rel.replace(/\.html$/i, '/');
+}
+
+function stripLangPrefix(pathname) {
+  const input = String(pathname || '/');
+  const parts = input.split('/').filter(Boolean);
+
+  if (parts.length && PREFIXED_LANGS.includes(parts[0])) {
+    const rest = parts.slice(1).join('/');
+    return '/' + rest + (input.endsWith('/') && rest ? '/' : '');
+  }
+
+  return input || '/';
+}
+
+function normalizeRoute(route) {
+  let out = String(route || '/');
+
+  out = out.split('?')[0].split('#')[0];
+  out = stripLangPrefix(out);
+
+  if (!out.startsWith('/')) out = '/' + out;
+
+  out = out.replace(/\/index\.html$/i, '/');
+  out = out.replace(/\.html$/i, '/');
+
+  if (out !== '/' && !out.endsWith('/')) out += '/';
+
+  return out;
+}
+
+function localizedRoute(route, lang) {
+  const clean = normalizeRoute(route);
+
+  if (lang === 'cs') return clean;
+  if (clean === '/') return `/${lang}/`;
+
+  return `/${lang}${clean}`;
+}
+
+
+function routeForCanonical(route, lang) {
+  const localized = localizedRoute(route, lang);
+
+  if (lang === 'cs' && CS_NO_TRAILING_CANONICAL_ROUTES.has(localized)) {
+    return localized.replace(/\/$/, '');
+  }
+
+  return localized;
+}
+
+function canonicalUrl(route, lang) {
+  return ORIGIN + routeForCanonical(route, lang);
+}
+
+function targetFileForRoute(route, lang) {
+  const localized = localizedRoute(route, lang).replace(/^\/+/, '');
+
+  if (!localized) return path.join(DIST, 'index.html');
+
+  return path.join(DIST, localized, 'index.html');
+}
+
+function getPageName(file, html) {
+  const bodyMatch = html.match(/<body\b[^>]*\bdata-page="([^"]+)"/i);
+  const bodyPage = bodyMatch ? String(bodyMatch[1] || '').trim() : '';
+
+  if (bodyPage && bodyPage !== 'home') return bodyPage;
+
+  const route = cleanRouteFromDistFile(file);
+  const parts = route.split('/').filter(Boolean);
+
+  if (!parts.length) return '';
+
+  if (parts[0] === 'blog' && parts.length >= 2) return 'blog-detail';
+  if (parts[0] === 'microguides') return 'microguides';
+  if (parts[0] === 'coming-soon') return parts[1] || 'coming-soon';
+
+  return parts[parts.length - 1] || '';
+}
+
+function loadDict(lang, pageName) {
+  const base =
+    readJson(path.join(ROOT, 'public', 'locales', `${lang}.json`), null) ||
+    readJson(path.join(ROOT, 'src', 'locales', `${lang}.json`), {});
+
+  const page = pageName
+    ? (
+        readJson(path.join(ROOT, 'public', 'locales', lang, `${pageName}.json`), null) ||
+        readJson(path.join(ROOT, 'src', 'locales', lang, `${pageName}.json`), {})
+      )
+    : {};
+
+  return deepMerge(base, page);
+}
+
+function replaceAttr(tag, attrName, value) {
+  const escaped = escapeAttr(value);
+  const re = new RegExp(`(^|\\s)${attrName}="[^"]*"`, 'i');
+
+  if (re.test(tag)) {
+    return tag.replace(re, `$1${attrName}="${escaped}"`);
+  }
+
+  return tag.replace(/>$/, ` ${attrName}="${escaped}">`);
+}
+
+function translateHtml(html, dict) {
+  html = html.replace(
+    /(<([a-zA-Z][\w:-]*)(?=[^>]*\bdata-i18n-key="([^"]+)")[^>]*>)([\s\S]*?)(<\/\2>)/g,
+    (full, open, tagName, key, inner, close) => {
+      const value = t(dict, key);
+      if (value === undefined || String(value).trim() === '') return full;
+
+      const rendered = /<[a-z][\s\S]*>/i.test(String(value))
+        ? String(value)
+        : escapeText(value);
+
+      return `${open}${rendered}${close}`;
+    }
+  );
+
+  html = html.replace(
+    /<title\b([^>]*)\bdata-i18n-key="([^"]+)"([^>]*)>[\s\S]*?<\/title>/gi,
+    (full, before, key, after) => {
+      const value = t(dict, key);
+      if (value === undefined || String(value).trim() === '') return full;
+
+      return `<title${before}data-i18n-key="${escapeAttr(key)}"${after}>${escapeText(value)}</title>`;
+    }
+  );
+
+  html = html.replace(
+    /<meta\b[^>]*\bdata-i18n-content="([^"]+)"[^>]*>/gi,
+    (full, key) => {
+      const value = t(dict, key);
+      if (value === undefined || String(value).trim() === '') return full;
+
+      return replaceAttr(full, 'content', value);
+    }
+  );
+
+  html = html.replace(
+    /<[^>]+\bdata-i18n-placeholder="([^"]+)"[^>]*>/gi,
+    (full, key) => {
+      const value = t(dict, key);
+      if (value === undefined || String(value).trim() === '') return full;
+
+      return replaceAttr(full, 'placeholder', value);
+    }
+  );
+
+  html = html.replace(
+    /<[^>]+\bdata-i18n-aria="([^"]+)"[^>]*>/gi,
+    (full, key) => {
+      const value = t(dict, key);
+      if (value === undefined || String(value).trim() === '') return full;
+
+      return replaceAttr(replaceAttr(full, 'aria-label', value), 'title', value);
+    }
+  );
+
+  html = html.replace(
+    /<[^>]+\bdata-i18n-alt="([^"]+)"[^>]*>/gi,
+    (full, key) => {
+      const value = t(dict, key);
+      if (value === undefined || String(value).trim() === '') return full;
+
+      return replaceAttr(full, 'alt', value);
+    }
+  );
+
+  return html;
+}
+
+function updateHtmlLang(html, lang) {
+  if (/<html\b/i.test(html)) {
+    return html.replace(/<html\b([^>]*)>/i, (full, attrs) => {
+      let tag = `<html${attrs}>`;
+      tag = replaceAttr(tag, 'lang', lang);
+      return tag;
+    });
+  }
+
+  return html;
+}
+
+function updateLangDropdown(html, lang) {
+  const meta = LANG_META[lang] || LANG_META.cs;
+
+  html = html.replace(
+    /(<([a-zA-Z][\w:-]*)\b(?=[^>]*class="[^"]*\blang-current-label\b[^"]*")[^>]*>)([\s\S]*?)(<\/\2>)/g,
+    (full, open, tag, inner, close) => `${open}${escapeText(meta.label)}${close}`
+  );
+
+  html = html.replace(
+    /<img\b(?=[^>]*class="[^"]*\blang-current-flag\b[^"]*")[^>]*>/gi,
+    (full) => {
+      let out = replaceAttr(full, 'src', meta.flag);
+      out = replaceAttr(out, 'alt', meta.label);
+      return out;
+    }
+  );
+
+  return html;
+}
+
+
+function updateStaticGeneratedLabels(html, lang) {
+  const blogReadMore = BLOG_READMORE_LABELS[lang] || BLOG_READMORE_LABELS.cs;
+
+  html = html.replace(
+    /(<a\b(?=[^>]*class="[^"]*\bblog-readmore\b[^"]*")[^>]*>)([\s\S]*?)(<\/a>)/gi,
+    (full, open, inner, close) => {
+      return `${open}${escapeText(blogReadMore)}${close}`;
+    }
+  );
+
+  return html;
+}
+
+function isSkippableHref(href) {
+  const value = String(href || '').trim();
+
+  if (!value) return true;
+  if (value.startsWith('#')) return true;
+  if (/^(mailto:|tel:|javascript:)/i.test(value)) return true;
+  if (/^\/\//.test(value)) return true;
+  if (/\.(png|jpe?g|webp|avif|svg|gif|pdf|zip|css|js|json|xml|txt|ico)$/i.test(value.split('?')[0])) return true;
+
+  return false;
+}
+
+function cleanSearch(url) {
+  const params = new URLSearchParams(url.search);
+  params.delete('lang');
+
+  const serialized = params.toString();
+  return serialized ? `?${serialized}` : '';
+}
+
+function localizeHref(href, currentLang, currentRoute, explicitTargetLang = null) {
+  if (isSkippableHref(href)) return href;
+
+  try {
+    const targetLang = explicitTargetLang || currentLang;
+    const baseUrl = ORIGIN + normalizeRoute(currentRoute);
+    const url = new URL(href, baseUrl);
+
+    if (url.origin !== ORIGIN) return href;
+
+    const route = explicitTargetLang
+      ? currentRoute
+      : normalizeRoute(url.pathname);
+
+    return localizedRoute(route, targetLang) + cleanSearch(url) + url.hash;
+  } catch {
+    return href;
+  }
+}
+
+function rewriteLinks(html, lang, route) {
+  return html.replace(/<a\b[^>]*\bhref="([^"]*)"[^>]*>/gi, (full, href) => {
+    const langMatch =
+      full.match(/\bdata-lang="(cs|en|de|sk|pl|hu)"/i) ||
+      full.match(/\bdata-lang-code="(cs|en|de|sk|pl|hu)"/i);
+
+    const explicitTargetLang = langMatch ? langMatch[1].toLowerCase() : null;
+    const nextHref = localizeHref(href, lang, route, explicitTargetLang);
+
+    return replaceAttr(full, 'href', nextHref);
+  });
+}
+
+function updateExistingMetaUrl(html, canonical) {
+  html = html.replace(
+    /<meta\b(?=[^>]*\bproperty=["']og:url["'])[^>]*>/gi,
+    (full) => replaceAttr(full, 'content', canonical)
+  );
+
+  html = html.replace(
+    /<meta\b(?=[^>]*\bname=["']twitter:url["'])[^>]*>/gi,
+    (full) => replaceAttr(full, 'content', canonical)
+  );
+
+  return html;
+}
+
+function applySeoLinks(html, route, lang) {
+  const canonical = canonicalUrl(route, lang);
+
+  const alternateLinks = LANGS
+    .map((itemLang) => {
+      return `<link rel="alternate" hreflang="${itemLang}" href="${escapeAttr(canonicalUrl(route, itemLang))}" />`;
+    })
+    .join('\n  ');
+
+  const seoBlock = [
+    `<link rel="canonical" href="${escapeAttr(canonical)}" />`,
+    alternateLinks,
+    `<link rel="alternate" hreflang="x-default" href="${escapeAttr(canonicalUrl(route, 'cs'))}" />`
+  ].join('\n  ');
+
+  html = updateExistingMetaUrl(html, canonical);
+
+  html = html.replace(/<link\b[^>]*\brel=["']canonical["'][^>]*>\s*/gi, '');
+  html = html.replace(/<link\b[^>]*\brel=["']alternate["'][^>]*\bhreflang=["'][^"']+["'][^>]*>\s*/gi, '');
+
+  if (/<\/head>/i.test(html)) {
+    return html.replace(/<\/head>/i, `  ${seoBlock}\n</head>`);
+  }
+
+  return html;
+}
+
+function processPage(sourceHtml, file, lang) {
+  const route = cleanRouteFromDistFile(file);
+  const pageName = getPageName(file, sourceHtml);
+  const dict = loadDict(lang, pageName);
+
+  let html = sourceHtml;
+
+  html = updateHtmlLang(html, lang);
+  html = translateHtml(html, dict);
+  html = updateLangDropdown(html, lang);
+  html = updateStaticGeneratedLabels(html, lang);
+  html = rewriteLinks(html, lang, route);
+  html = applySeoLinks(html, route, lang);
+
+  return html;
+}
+
+function removeOldLocalizedDirs() {
+  for (const lang of PREFIXED_LANGS) {
+    const dir = path.join(DIST, lang);
+
+    if (fs.existsSync(dir)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+}
+
+function main() {
+  if (!fs.existsSync(DIST)) {
+    throw new Error('dist/ does not exist. Run npm run build first.');
+  }
+
+  removeOldLocalizedDirs();
+
+  const pages = walk(DIST).map((file) => ({
+    file,
+    route: cleanRouteFromDistFile(file),
+    html: fs.readFileSync(file, 'utf8')
+  }));
+
+  let written = 0;
+
+  for (const page of pages) {
+    const csHtml = processPage(page.html, page.file, 'cs');
+    fs.writeFileSync(page.file, csHtml, 'utf8');
+    written++;
+
+    for (const lang of PREFIXED_LANGS) {
+      const localizedHtml = processPage(page.html, page.file, lang);
+      const target = targetFileForRoute(page.route, lang);
+
+      ensureDir(path.dirname(target));
+      fs.writeFileSync(target, localizedHtml, 'utf8');
+      written++;
+    }
+  }
+
+  console.log('AJSEE localized static pages generated');
+  console.log('============================================================');
+  console.log(`Source pages: ${pages.length}`);
+  console.log(`Languages: ${LANGS.join(', ')}`);
+  console.log(`HTML files written: ${written}`);
+}
+
+main();

--- a/scripts/build-localized-pages.cjs
+++ b/scripts/build-localized-pages.cjs
@@ -374,6 +374,22 @@ function updateStaticGeneratedLabels(html, lang) {
   return html;
 }
 
+
+function updateStaticA11yLabels(html, dict, lang) {
+  const homeLabel = t(dict, 'nav-home') || (LANG_META[lang]?.label || LANG_META.cs.label);
+
+  html = html.replace(
+    /<a\b(?=[^>]*class="[^"]*\blogo-link\b[^"]*")[^>]*>/gi,
+    (full) => {
+      let out = replaceAttr(full, 'aria-label', homeLabel);
+      out = replaceAttr(out, 'title', homeLabel);
+      return out;
+    }
+  );
+
+  return html;
+}
+
 function isSkippableHref(href) {
   const value = String(href || '').trim();
 
@@ -479,6 +495,7 @@ function processPage(sourceHtml, file, lang) {
   html = translateHtml(html, dict);
   html = updateLangDropdown(html, lang);
   html = updateStaticGeneratedLabels(html, lang);
+  html = updateStaticA11yLabels(html, dict, lang);
   html = rewriteLinks(html, lang, route);
   html = applySeoLinks(html, route, lang);
 

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -129,6 +129,83 @@ const TRANSLATIONS_CACHE = new Map();
 const TRANSLATIONS_PROMISE_CACHE = new Map();
 const I18N_PREFETCHED = new Set();
 
+/* AJSEE language URL helpers: canonical path-prefix URLs, no runtime ?lang links. */
+const AJSEE_CANONICAL_LANGS = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+
+function ajseeCanonicalLang(value) {
+  const lang = String(value || '').trim().toLowerCase().slice(0, 2);
+  return AJSEE_CANONICAL_LANGS.includes(lang) ? lang : 'cs';
+}
+
+function ajseePathLang(pathname = window.location.pathname) {
+  const match = String(pathname || '').match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+  return match ? ajseeCanonicalLang(match[1]) : '';
+}
+
+function ajseeStripLangPrefix(pathname = '/') {
+  let path = String(pathname || '/');
+  path = path.replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+  if (!path) path = '/';
+  if (!path.startsWith('/')) path = '/' + path;
+  return path;
+}
+
+function ajseeBuildLocalizedPath(pathname = '/', lang = 'cs') {
+  const targetLang = ajseeCanonicalLang(lang);
+  let path = ajseeStripLangPrefix(pathname || '/');
+
+  path = path.replace(/\/index\.html$/i, '/');
+  path = path.replace(/\.html$/i, '');
+  path = path.replace(/\/{2,}/g, '/');
+
+  if (!path.startsWith('/')) path = '/' + path;
+  if (path !== '/' && !path.endsWith('/')) path += '/';
+
+  return targetLang === 'cs'
+    ? path
+    : '/' + targetLang + (path === '/' ? '/' : path);
+}
+
+function ajseeLocalizedUrlForLang(lang, href = window.location.href) {
+  const targetLang = ajseeCanonicalLang(lang);
+
+  try {
+    const url = new URL(href, window.location.origin);
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, targetLang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return targetLang === 'cs' ? '/' : '/' + targetLang + '/';
+  }
+}
+
+function ajseeLocalizeInternalHref(rawHref, lang) {
+  if (!rawHref) return rawHref;
+  if (String(rawHref).startsWith('#')) return rawHref;
+  if (/^(mailto:|tel:|javascript:)/i.test(String(rawHref))) return rawHref;
+  if (/^https?:\/\//i.test(String(rawHref)) && !String(rawHref).startsWith(window.location.origin)) return rawHref;
+
+  try {
+    const url = new URL(rawHref, window.location.origin);
+    if (url.origin !== window.location.origin) return rawHref;
+
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, lang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return rawHref;
+  }
+}
+
+
 /* ───────── basic utils ───────── */
 const qs = (s, r = document) => r.querySelector(s);
 const qsa = (s, r = document) => Array.from(r.querySelectorAll(s));
@@ -225,19 +302,9 @@ function getUILang() {
   const fromUrl = normalize(sp.get('lang') || sp.get('locale') || sp.get('hl'));
   const pathMatch = location.pathname.match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
   const fromPath = normalize(pathMatch && pathMatch[1]);
-  const fromCookie = normalize(
-    (document.cookie.split('; ').find(r => r.startsWith('aj_lang=')) || '').split('=')[1]
-  );
 
-  let fromStorage = '';
-  try {
-    fromStorage = normalize(localStorage.getItem('ajsee.lang'));
-  } catch {
-    fromStorage = '';
-  }
-
-  const fromHtml = normalize(document.documentElement.getAttribute('lang'));
-  return fromUrl || fromPath || fromCookie || fromStorage || fromHtml || 'cs';
+  // Canonical rule: URL/query decides language. Non-prefixed pages are always Czech.
+  return fromUrl || fromPath || 'cs';
 }
 
 function setLangCookie(lang) {
@@ -774,23 +841,7 @@ function pickLocalized(val, lang) {
 }
 
 function withLangParam(href, lang) {
-  try {
-    const u = new URL(href, location.origin);
-    if (u.origin !== location.origin) return u.toString();
-    if (!u.searchParams.has('lang')) u.searchParams.set('lang', lang);
-    return u.toString();
-  } catch {
-    if (typeof href === 'string' && href.startsWith('/')) {
-      try {
-        const u = new URL(href, location.origin);
-        if (!u.searchParams.has('lang')) u.searchParams.set('lang', lang);
-        return u.toString();
-      } catch {
-        /* noop */
-      }
-    }
-    return href || '#';
-  }
+  return ajseeLocalizeInternalHref(href, lang);
 }
 
 function fixHomeBlog() {
@@ -1376,30 +1427,47 @@ async function applyTranslations(lang) {
     const key = el.getAttribute('data-i18n-key');
     const value = t(key);
     if (value === undefined || String(value).trim() === '') return;
-    if (/[<][a-z]/i.test(value)) el.innerHTML = value;
-    else el.textContent = value;
+    if (/[<][a-z]/i.test(value)) {
+      const next = String(value);
+      if (el.innerHTML !== next) el.innerHTML = next;
+    } else {
+      const next = String(value);
+      if (el.textContent !== next) el.textContent = next;
+    }
   });
 
   document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
     const value = t(el.getAttribute('data-i18n-placeholder'));
-    if (value) el.setAttribute('placeholder', String(value));
+    if (value) {
+      const next = String(value);
+      if (el.getAttribute('placeholder') !== next) el.setAttribute('placeholder', next);
+    }
   });
 
   document.querySelectorAll('[data-i18n-aria]').forEach(el => {
     const value = t(el.getAttribute('data-i18n-aria'));
     if (!value) return;
-    el.setAttribute('aria-label', String(value));
-    el.setAttribute('title', String(value));
+    {
+      const next = String(value);
+      if (el.getAttribute('aria-label') !== next) el.setAttribute('aria-label', next);
+      if (el.getAttribute('title') !== next) el.setAttribute('title', next);
+    }
   });
 
   document.querySelectorAll('[data-i18n-alt]').forEach(el => {
     const value = t(el.getAttribute('data-i18n-alt'));
-    if (value) el.setAttribute('alt', String(value));
+    if (value) {
+      const next = String(value);
+      if (el.getAttribute('alt') !== next) el.setAttribute('alt', next);
+    }
   });
 
   document.querySelectorAll('[data-i18n-content]').forEach(el => {
     const value = t(el.getAttribute('data-i18n-content'));
-    if (value !== undefined && String(value).trim() !== '') el.setAttribute('content', String(value));
+    if (value !== undefined && String(value).trim() !== '') {
+      const next = String(value);
+      if (el.getAttribute('content') !== next) el.setAttribute('content', next);
+    }
   });
 
   syncLocalizedCityLabelFromCurrentState();
@@ -2951,18 +3019,14 @@ function initEventsScrollGuard() {
 function changeLangTo(lang) {
   const next = String(lang || '').trim().toLowerCase();
   if (!SUPPORTED_LANGS.includes(next)) return;
-  if (next === currentLang) return;
+  if (next === currentLang && ajseePathLang(location.pathname) === next) return;
 
   currentLang = next;
   setLangCookie(currentLang);
 
   try { localStorage.setItem('ajsee.lang', currentLang); } catch { /* noop */ }
 
-  const u = new URL(location.href);
-  if (currentLang === 'cs') u.searchParams.delete('lang');
-  else u.searchParams.set('lang', currentLang);
-  history.replaceState(null, '', u.toString());
-
+  history.replaceState(null, '', ajseeLocalizedUrlForLang(currentLang));
   document.documentElement.lang = currentLang;
 
   window.dispatchEvent(new CustomEvent('AJSEE:langChanged', { detail: { lang: currentLang } }));
@@ -2998,11 +3062,13 @@ function syncLangDropdownUI(lang) {
       if (selected) {
         const img = btn.querySelector('img');
         if (img && currentFlag) {
-          currentFlag.src = img.getAttribute('src') || img.src;
-          currentFlag.alt = img.getAttribute('alt') || img.alt || '';
+          const nextSrc = img.getAttribute('src') || img.src;
+          const nextAlt = img.getAttribute('alt') || img.alt || '';
+          if (currentFlag.getAttribute('src') !== nextSrc) currentFlag.setAttribute('src', nextSrc);
+          if (currentFlag.getAttribute('alt') !== nextAlt) currentFlag.setAttribute('alt', nextAlt);
         }
         const txt = (btn.textContent || '').trim();
-        if (currentLabel && txt) currentLabel.textContent = txt;
+        if (currentLabel && txt && currentLabel.textContent !== txt) currentLabel.textContent = txt;
       }
     });
   });
@@ -3113,8 +3179,7 @@ function updateHomeCtasWithLang() {
   if (wlCta) {
     try {
       const u = new URL(wlCta.getAttribute('href') || wlCta.href || '/coming-soon', location.origin);
-      if (SUPPORTED_LANGS.includes(lang)) u.searchParams.set('lang', lang);
-      wlCta.href = u.toString();
+      if (SUPPORTED_LANGS.includes(lang)) wlCta.href = ajseeLocalizeInternalHref(u.pathname + u.search + u.hash, lang);
     } catch {
       /* noop */
     }
@@ -3134,8 +3199,7 @@ function updateHomeCtasWithLang() {
   if (demoCta) {
     try {
       const u = new URL(demoCta.getAttribute('href') || demoCta.href || '/coming-soon', location.origin);
-      u.searchParams.set('lang', lang);
-      demoCta.href = u.toString();
+      demoCta.href = ajseeLocalizeInternalHref(u.pathname + u.search + u.hash, lang);
     } catch {
       /* noop */
     }

--- a/src/faq.js
+++ b/src/faq.js
@@ -1,147 +1,135 @@
 // /src/faq.js
+// ---------------------------------------------------------
+// AJSEE – FAQ page behavior only
+// ---------------------------------------------------------
+// Důležité:
+// Jazyk, menu, URL a překlady řeší faq-entry.js + i18n.js + nav-core.js.
+// Tento soubor už NESMÍ detekovat jazyk, načítat /locales/*.json,
+// přepisovat navigaci ani přidávat ?lang= do odkazů.
+// Řeší pouze FAQ akordeon a FAQPage JSON-LD podle aktuálního DOM.
+// ---------------------------------------------------------
 
-// --- Detekce a aplikace jazyka, načtení překladů ---
-function detectLang() {
-  const urlLang = new URLSearchParams(window.location.search).get('lang');
-  if (urlLang && ['cs', 'en', 'de', 'sk', 'pl', 'hu'].includes(urlLang)) return urlLang;
-  let lang = (navigator.language || 'cs').slice(0, 2).toLowerCase();
-  if (!["cs", "en", "de", "sk", "pl", "hu"].includes(lang)) lang = "cs";
-  return lang;
+function textFrom(el) {
+  return String(el?.textContent || '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
-// Načti překladový soubor
-async function loadTranslations(lang) {
-  const resp = await fetch(`/locales/${lang}.json`);
-  return await resp.json();
-}
-
-// Aplikuj překlady do stránky
-async function applyTranslations(lang) {
-  const translations = await loadTranslations(lang);
-  window.translations = translations;
-
-  document.querySelectorAll('[data-i18n-key]').forEach(el => {
-    const key = el.getAttribute('data-i18n-key');
-    if (translations[key]) el.textContent = translations[key];
-  });
-  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
-    const key = el.getAttribute('data-i18n-placeholder');
-    if (translations[key]) el.placeholder = translations[key];
-  });
-
-  // Po každém překladu znovu renderuj FAQ JSON-LD (SEO)
-  renderFAQJsonLD();
-}
-
-// --- FAQ rozbalování, OPRAVENO pro .open ---
 function initFaqAccordion() {
-  document.querySelectorAll('.faq-question').forEach(btn => {
+  document.querySelectorAll('.faq-question').forEach((btn) => {
+    if (btn.dataset.ajseeFaqBound === '1') return;
+    btn.dataset.ajseeFaqBound = '1';
+
     btn.addEventListener('click', () => {
       const item = btn.closest('.faq-item');
+      if (!item) return;
+
       const expanded = btn.getAttribute('aria-expanded') === 'true';
 
-      // Zavři všechny ostatní (akordeon styl)
-      document.querySelectorAll('.faq-item').forEach(faq => {
+      document.querySelectorAll('.faq-item').forEach((faq) => {
         faq.classList.remove('open');
-        faq.querySelector('.faq-question').setAttribute('aria-expanded', 'false');
+
+        const question = faq.querySelector('.faq-question');
+        if (question) question.setAttribute('aria-expanded', 'false');
       });
 
-      // Pokud nebylo otevřeno, otevři tuto
       if (!expanded) {
         item.classList.add('open');
         btn.setAttribute('aria-expanded', 'true');
       }
-      // Pokud bylo otevřeno, vše je zavřeno
     });
   });
 }
 
-// --- FAQ JSON-LD (SEO) dynamicky pro aktuální jazyk ---
-function renderFAQJsonLD() {
-  const translations = window.translations || {};
-  // Najdi všechny klíče pro otázky (např. faq-q1, faq-q2, ...)
-  const faqKeys = Object.keys(translations).filter(k => /^faq-q\d+$/.test(k));
-  if (faqKeys.length === 0) return;
+function getAnswerForItem(item) {
+  if (!item) return '';
 
-  faqKeys.sort((a, b) => {
-    const na = parseInt(a.replace('faq-q', ''), 10);
-    const nb = parseInt(b.replace('faq-q', ''), 10);
-    return na - nb;
-  });
+  const direct =
+    item.querySelector('.faq-answer') ||
+    item.querySelector('[data-faq-answer]') ||
+    item.querySelector('.faq-response');
 
-  const faqJson = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": faqKeys.map(qKey => {
-      const aKey = qKey.replace('q', 'a');
+  if (direct) return textFrom(direct);
+
+  const question = item.querySelector('.faq-question');
+  const clone = item.cloneNode(true);
+
+  clone.querySelectorAll('.faq-question, button, svg').forEach((el) => el.remove());
+
+  const text = textFrom(clone);
+
+  if (question) {
+    return text.replace(textFrom(question), '').trim();
+  }
+
+  return text;
+}
+
+function collectFaqItemsFromDom() {
+  return Array.from(document.querySelectorAll('.faq-item'))
+    .map((item) => {
+      const questionEl =
+        item.querySelector('.faq-question') ||
+        item.querySelector('[data-faq-question]');
+
       return {
-        "@type": "Question",
-        "name": translations[qKey],
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": translations[aKey] || ""
-        }
+        question: textFrom(questionEl),
+        answer: getAnswerForItem(item)
       };
     })
+    .filter((item) => item.question && item.answer);
+}
+
+function renderFAQJsonLD() {
+  const items = collectFaqItemsFromDom();
+
+  document.querySelectorAll('script[data-faq-jsonld]').forEach((el) => el.remove());
+
+  if (!items.length) return;
+
+  const faqJson = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: items.map((item) => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer
+      }
+    }))
   };
 
-  // Odstraň předchozí JSON-LD blok (pokud existuje)
-  document.querySelectorAll('script[data-faq-jsonld]').forEach(el => el.remove());
-
-  // Vlož nový blok
   const script = document.createElement('script');
   script.type = 'application/ld+json';
   script.setAttribute('data-faq-jsonld', '1');
   script.textContent = JSON.stringify(faqJson, null, 2);
+
   document.head.appendChild(script);
 }
 
-// --- Aktivace menu odkazu ---
-function activateNavLink() {
-  const path = window.location.pathname;
-  document.querySelectorAll('.main-nav a').forEach(link => {
-    const href = link.getAttribute('href');
-    if ((path === '/' || path.endsWith('index.html')) && (href === '/' || href === '/index.html')) {
-      link.classList.add('active');
-    } else if (path.endsWith('faq.html') && href.includes('faq')) {
-      link.classList.add('active');
-    } else {
-      link.classList.remove('active');
-    }
+function scheduleFAQJsonLD() {
+  renderFAQJsonLD();
+
+  window.requestAnimationFrame(() => {
+    renderFAQJsonLD();
   });
+
+  window.setTimeout(renderFAQJsonLD, 120);
+  window.setTimeout(renderFAQJsonLD, 500);
 }
 
-// --- Aktualizace menu odkazů s lang parametrem ---
-function updateMenuLinksWithLang(lang) {
-  document.querySelectorAll('.main-nav a').forEach(link => {
-    let href = link.getAttribute('href');
-    if (!href || href.startsWith('mailto:') || href.startsWith('http')) return;
-    href = href.replace(/\?lang=[a-z]{2}/, '').replace(/&lang=[a-z]{2}/, '');
-    if (href.includes('?')) {
-      href = `${href}&lang=${lang}`;
-    } else {
-      href = `${href}?lang=${lang}`;
-    }
-    link.setAttribute('href', href);
-  });
-}
-
-// --- INIT (DOM Ready) ---
-document.addEventListener('DOMContentLoaded', async () => {
-  const lang = detectLang();
-  updateMenuLinksWithLang(lang);
-  await applyTranslations(lang);
+function bootFaqBehavior() {
   initFaqAccordion();
-  activateNavLink();
+  scheduleFAQJsonLD();
+}
 
-  // Jazykové přepínače – reload se správným lang parametrem
-  document.querySelectorAll('.lang-btn').forEach(btn => {
-    btn.addEventListener("click", (e) => {
-      e.preventDefault();
-      const chosenLang = btn.dataset.lang;
-      const url = new URL(window.location.href);
-      url.searchParams.set('lang', chosenLang);
-      window.location.href = url.toString();
-    });
-  });
-});
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', bootFaqBehavior, { once: true });
+} else {
+  bootFaqBehavior();
+}
+
+window.addEventListener('ajsee:lang-changed', scheduleFAQJsonLD);
+window.addEventListener('AJSEE:langChanged', scheduleFAQJsonLD);
+window.addEventListener('ajsee:i18n-applied', scheduleFAQJsonLD);

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,6 +7,83 @@ export const translations = {}; // živý objekt – neměň referenci
 const SUPPORTED = ['cs','en','de','sk','pl','hu'];
 const LANG_KEY = 'ajsee.lang';
 
+/* AJSEE language URL helpers: canonical path-prefix URLs, no runtime ?lang links. */
+const AJSEE_CANONICAL_LANGS = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+
+function ajseeCanonicalLang(value) {
+  const lang = String(value || '').trim().toLowerCase().slice(0, 2);
+  return AJSEE_CANONICAL_LANGS.includes(lang) ? lang : 'cs';
+}
+
+function ajseePathLang(pathname = window.location.pathname) {
+  const match = String(pathname || '').match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+  return match ? ajseeCanonicalLang(match[1]) : '';
+}
+
+function ajseeStripLangPrefix(pathname = '/') {
+  let path = String(pathname || '/');
+  path = path.replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+  if (!path) path = '/';
+  if (!path.startsWith('/')) path = '/' + path;
+  return path;
+}
+
+function ajseeBuildLocalizedPath(pathname = '/', lang = 'cs') {
+  const targetLang = ajseeCanonicalLang(lang);
+  let path = ajseeStripLangPrefix(pathname || '/');
+
+  path = path.replace(/\/index\.html$/i, '/');
+  path = path.replace(/\.html$/i, '');
+  path = path.replace(/\/{2,}/g, '/');
+
+  if (!path.startsWith('/')) path = '/' + path;
+  if (path !== '/' && !path.endsWith('/')) path += '/';
+
+  return targetLang === 'cs'
+    ? path
+    : '/' + targetLang + (path === '/' ? '/' : path);
+}
+
+function ajseeLocalizedUrlForLang(lang, href = window.location.href) {
+  const targetLang = ajseeCanonicalLang(lang);
+
+  try {
+    const url = new URL(href, window.location.origin);
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, targetLang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return targetLang === 'cs' ? '/' : '/' + targetLang + '/';
+  }
+}
+
+function ajseeLocalizeInternalHref(rawHref, lang) {
+  if (!rawHref) return rawHref;
+  if (String(rawHref).startsWith('#')) return rawHref;
+  if (/^(mailto:|tel:|javascript:)/i.test(String(rawHref))) return rawHref;
+  if (/^https?:\/\//i.test(String(rawHref)) && !String(rawHref).startsWith(window.location.origin)) return rawHref;
+
+  try {
+    const url = new URL(rawHref, window.location.origin);
+    if (url.origin !== window.location.origin) return rawHref;
+
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, lang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return rawHref;
+  }
+}
+
+
 /**
  * Vite loader pro JSON v /src/locales (např. "./locales/cs/accommodation.json")
  * Klíče: "./locales/cs/accommodation.json" atd.
@@ -93,27 +170,18 @@ function setCookieLang(lang) {
 function persistLang(lang) {
   const l = normalizeLang(lang) || 'cs';
 
-  // ✅ storage (existing)
   try { localStorage.setItem(LANG_KEY, l); } catch {}
-
-  // ✅ cookie (NEW: unify language across pages)
   setCookieLang(l);
 
-  // ✅ html lang
   try { document.documentElement.setAttribute('lang', l); } catch {}
 
-  // sync URL (bez reloadu) – cs = čistá URL bez parametru
   try {
-    const url = new URL(window.location.href);
-    if (l === 'cs') url.searchParams.delete('lang');
-    else url.searchParams.set('lang', l);
-
-    if (url.toString() !== window.location.href) {
-      history.replaceState({}, '', url.toString());
+    const nextUrl = ajseeLocalizedUrlForLang(l);
+    if (nextUrl !== (window.location.pathname + window.location.search + window.location.hash)) {
+      history.replaceState({}, '', nextUrl);
     }
   } catch {}
 
-  // event pro ostatní části UI (nav linky apod.)
   try {
     window.dispatchEvent(new CustomEvent('ajsee:lang-changed', { detail: { lang: l } }));
   } catch {}
@@ -135,33 +203,24 @@ export function patchInternalLinksWithLang(lang) {
 
     if (raw.startsWith('#')) return;
     if (/^(mailto:|tel:|javascript:)/i.test(raw)) return;
-    if (/^https?:\/\//i.test(raw)) return;
+    if (/^https?:\/\//i.test(raw) && !raw.startsWith(window.location.origin)) return;
 
     let u;
     try { u = new URL(raw, window.location.origin); } catch { return; }
     if (u.origin !== window.location.origin) return;
     if (!isNavLinkCandidate(u)) return;
 
-    if (l === 'cs') u.searchParams.delete('lang');
-    else u.searchParams.set('lang', l);
-
-    const next =
-      u.pathname +
-      (u.searchParams.toString() ? `?${u.searchParams.toString()}` : '') +
-      (u.hash || '');
-    a.setAttribute('href', next);
+    a.setAttribute('href', ajseeLocalizeInternalHref(raw, l));
   });
 }
 
 /* ───────── veřejné API ───────── */
 export function detectLang() {
   const urlLang = normalizeLang(new URLSearchParams(location.search).get('lang'));
-  const cookieLang = getCookieLang();
-  const stored = getStoredLang();
-  const htmlLang = normalizeLang(document.documentElement.getAttribute('lang'));
+  const pathLang = ajseePathLang(location.pathname);
 
-  // ✅ pořadí sjednocené s main.js: URL -> cookie -> storage -> <html lang> -> cs
-  return urlLang || cookieLang || stored || htmlLang || 'cs';
+  // Canonical rule: URL/query decides language. Non-prefixed pages are always Czech.
+  return urlLang || pathLang || 'cs';
 }
 
 function getByPath(o, p) {
@@ -280,23 +339,34 @@ export async function applyTranslations(lang = detectLang()) {
     const k = el.getAttribute('data-i18n-key');
     const v = t(k);
     if (v === undefined || String(v).trim() === '') return;
-    if (/[<][a-z]/i.test(v)) el.innerHTML = v;
-    else el.textContent = v;
+    if (/[<][a-z]/i.test(v)) {
+      const next = String(v);
+      if (el.innerHTML !== next) el.innerHTML = next;
+    } else {
+      const next = String(v);
+      if (el.textContent !== next) el.textContent = next;
+    }
   });
 
   document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
     const k = el.getAttribute('data-i18n-placeholder');
     const v = t(k);
     if (!v) return;
-    el.setAttribute('placeholder', String(v));
+    {
+      const next = String(v);
+      if (el.getAttribute('placeholder') !== next) el.setAttribute('placeholder', next);
+    }
   });
 
   document.querySelectorAll('[data-i18n-aria]').forEach((el) => {
     const k = el.getAttribute('data-i18n-aria');
     const v = t(k);
     if (typeof v === 'string' && v.trim()) {
-      el.setAttribute('aria-label', v);
-      el.setAttribute('title', v);
+      {
+      const next = String(v);
+      if (el.getAttribute('aria-label') !== next) el.setAttribute('aria-label', next);
+      if (el.getAttribute('title') !== next) el.setAttribute('title', next);
+    }
     }
   });
 
@@ -304,7 +374,10 @@ export async function applyTranslations(lang = detectLang()) {
     const k = el.getAttribute('data-i18n-alt');
     const v = t(k);
     if (!v) return;
-    el.setAttribute('alt', String(v));
+    {
+      const next = String(v);
+      if (el.getAttribute('alt') !== next) el.setAttribute('alt', next);
+    }
   });
 
   // meta/og content překlady (content="...")
@@ -312,11 +385,15 @@ export async function applyTranslations(lang = detectLang()) {
     const k = el.getAttribute('data-i18n-content');
     const v = t(k);
     if (v === undefined || String(v).trim() === '') return;
-    el.setAttribute('content', String(v));
+    {
+      const next = String(v);
+      if (el.getAttribute('content') !== next) el.setAttribute('content', next);
+    }
   });
 
   // 2b) oprav interní odkazy -> přenese lang dál
   try { patchInternalLinksWithLang(l); } catch {}
+  try { document.documentElement.classList.add('ajsee-i18n-ready', 'ajsee-i18n-head-ready'); } catch {}
 
   // 3) globální UI helpery
   try {

--- a/src/main.js
+++ b/src/main.js
@@ -119,6 +119,83 @@ const TRANSLATIONS_PROMISE_CACHE = new Map();
 
 const I18N_PREFETCHED = new Set();
 
+/* AJSEE language URL helpers: canonical path-prefix URLs, no runtime ?lang links. */
+const AJSEE_CANONICAL_LANGS = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+
+function ajseeCanonicalLang(value) {
+  const lang = String(value || '').trim().toLowerCase().slice(0, 2);
+  return AJSEE_CANONICAL_LANGS.includes(lang) ? lang : 'cs';
+}
+
+function ajseePathLang(pathname = window.location.pathname) {
+  const match = String(pathname || '').match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+  return match ? ajseeCanonicalLang(match[1]) : '';
+}
+
+function ajseeStripLangPrefix(pathname = '/') {
+  let path = String(pathname || '/');
+  path = path.replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+  if (!path) path = '/';
+  if (!path.startsWith('/')) path = '/' + path;
+  return path;
+}
+
+function ajseeBuildLocalizedPath(pathname = '/', lang = 'cs') {
+  const targetLang = ajseeCanonicalLang(lang);
+  let path = ajseeStripLangPrefix(pathname || '/');
+
+  path = path.replace(/\/index\.html$/i, '/');
+  path = path.replace(/\.html$/i, '');
+  path = path.replace(/\/{2,}/g, '/');
+
+  if (!path.startsWith('/')) path = '/' + path;
+  if (path !== '/' && !path.endsWith('/')) path += '/';
+
+  return targetLang === 'cs'
+    ? path
+    : '/' + targetLang + (path === '/' ? '/' : path);
+}
+
+function ajseeLocalizedUrlForLang(lang, href = window.location.href) {
+  const targetLang = ajseeCanonicalLang(lang);
+
+  try {
+    const url = new URL(href, window.location.origin);
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, targetLang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return targetLang === 'cs' ? '/' : '/' + targetLang + '/';
+  }
+}
+
+function ajseeLocalizeInternalHref(rawHref, lang) {
+  if (!rawHref) return rawHref;
+  if (String(rawHref).startsWith('#')) return rawHref;
+  if (/^(mailto:|tel:|javascript:)/i.test(String(rawHref))) return rawHref;
+  if (/^https?:\/\//i.test(String(rawHref)) && !String(rawHref).startsWith(window.location.origin)) return rawHref;
+
+  try {
+    const url = new URL(rawHref, window.location.origin);
+    if (url.origin !== window.location.origin) return rawHref;
+
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, lang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return rawHref;
+  }
+}
+
+
 /* ───────── utils ───────── */
 const qs = (s, r = document) => r.querySelector(s);
 const qsa = (s, r = document) => Array.from(r.querySelectorAll(s));
@@ -139,27 +216,13 @@ function getUILang() {
   };
 
   const sp = new URLSearchParams(location.search);
-
   const fromUrl = normalize(sp.get('lang') || sp.get('locale') || sp.get('hl'));
 
   const pathMatch = location.pathname.match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
   const fromPath = normalize(pathMatch && pathMatch[1]);
 
-  const fromCookie = normalize(
-    (document.cookie.split('; ').find(r => r.startsWith('aj_lang=')) || '').split('=')[1]
-  );
-
-  let fromStorage = '';
-  try {
-    fromStorage = normalize(localStorage.getItem('ajsee.lang'));
-  } catch {
-    fromStorage = '';
-  }
-
-  const fromHtml = normalize(document.documentElement.getAttribute('lang'));
-
-  // Důležité: <html lang="cs"> je v HTML defaultně, proto musí být cookie/storage před html.
-  return fromUrl || fromPath || fromCookie || fromStorage || fromHtml || 'cs';
+  // Canonical rule: URL/query decides language. Non-prefixed pages are always Czech.
+  return fromUrl || fromPath || 'cs';
 }
 
 function setLangCookie(lang) {
@@ -936,25 +999,7 @@ function pickLocalized(val, lang) {
 }
 
 function withLangParam(href, lang) {
-  try {
-    const u = new URL(href, location.origin);
-    if (u.origin !== location.origin) return u.toString();
-
-    if (!u.searchParams.has('lang')) u.searchParams.set('lang', lang);
-    return u.toString();
-  } catch {
-    if (typeof href === 'string' && href.startsWith('/')) {
-      try {
-        const u = new URL(href, location.origin);
-        if (!u.searchParams.has('lang')) u.searchParams.set('lang', lang);
-        return u.toString();
-      } catch {
-        /* noop */
-      }
-    }
-
-    return href || '#';
-  }
+  return ajseeLocalizeInternalHref(href, lang);
 }
 
 function getHomeBlogHost() {
@@ -1340,37 +1385,54 @@ async function applyTranslations(lang) {
     const value = t(key);
 
     if (value === undefined || String(value).trim() === '') return;
-    if (/[<][a-z]/i.test(value)) el.innerHTML = value;
-    else el.textContent = value;
+    if (/[<][a-z]/i.test(value)) {
+      const next = String(value);
+      if (el.innerHTML !== next) el.innerHTML = next;
+    } else {
+      const next = String(value);
+      if (el.textContent !== next) el.textContent = next;
+    }
   });
 
   document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
     const key = el.getAttribute('data-i18n-placeholder');
     const value = t(key);
     if (!value) return;
-    el.setAttribute('placeholder', String(value));
+    {
+      const next = String(value);
+      if (el.getAttribute('placeholder') !== next) el.setAttribute('placeholder', next);
+    }
   });
 
   document.querySelectorAll('[data-i18n-aria]').forEach(el => {
     const key = el.getAttribute('data-i18n-aria');
     const value = t(key);
     if (!value) return;
-    el.setAttribute('aria-label', String(value));
-    el.setAttribute('title', String(value));
+    {
+      const next = String(value);
+      if (el.getAttribute('aria-label') !== next) el.setAttribute('aria-label', next);
+      if (el.getAttribute('title') !== next) el.setAttribute('title', next);
+    }
   });
 
   document.querySelectorAll('[data-i18n-alt]').forEach(el => {
     const key = el.getAttribute('data-i18n-alt');
     const value = t(key);
     if (!value) return;
-    el.setAttribute('alt', String(value));
+    {
+      const next = String(value);
+      if (el.getAttribute('alt') !== next) el.setAttribute('alt', next);
+    }
   });
 
   document.querySelectorAll('[data-i18n-content]').forEach(el => {
     const key = el.getAttribute('data-i18n-content');
     const value = t(key);
     if (value === undefined || String(value).trim() === '') return;
-    el.setAttribute('content', String(value));
+    {
+      const next = String(value);
+      if (el.getAttribute('content') !== next) el.setAttribute('content', next);
+    }
   });
 
   syncLocalizedCityLabelFromCurrentState();
@@ -3065,7 +3127,7 @@ function changeLangTo(lang) {
   const next = String(lang || '').trim().toLowerCase();
 
   if (!supported.includes(next)) return;
-  if (next === currentLang) return;
+  if (next === currentLang && ajseePathLang(location.pathname) === next) return;
 
   currentLang = next;
 
@@ -3077,16 +3139,7 @@ function changeLangTo(lang) {
     /* noop */
   }
 
-  const u = new URL(location.href);
-
-  if (currentLang === 'cs') {
-    u.searchParams.delete('lang');
-  } else {
-    u.searchParams.set('lang', currentLang);
-  }
-
-  history.replaceState(null, '', u.toString());
-
+  history.replaceState(null, '', ajseeLocalizedUrlForLang(currentLang));
   document.documentElement.lang = currentLang;
 
   window.dispatchEvent(new CustomEvent('AJSEE:langChanged', {
@@ -3354,12 +3407,14 @@ function syncLangDropdownUI(lang) {
       if (selected) {
         const img = btn.querySelector('img');
         if (img && currentFlag) {
-          currentFlag.src = img.getAttribute('src') || img.src;
-          currentFlag.alt = img.getAttribute('alt') || img.alt || '';
+          const nextSrc = img.getAttribute('src') || img.src;
+          const nextAlt = img.getAttribute('alt') || img.alt || '';
+          if (currentFlag.getAttribute('src') !== nextSrc) currentFlag.setAttribute('src', nextSrc);
+          if (currentFlag.getAttribute('alt') !== nextAlt) currentFlag.setAttribute('alt', nextAlt);
         }
 
         const txt = (btn.textContent || '').trim();
-        if (currentLabel && txt) currentLabel.textContent = txt;
+        if (currentLabel && txt && currentLabel.textContent !== txt) currentLabel.textContent = txt;
       }
     });
   });
@@ -3444,8 +3499,7 @@ function updateHomeCtasWithLang() {
   if (wlCta) {
     try {
       const u = new URL(wlCta.getAttribute('href') || wlCta.href || '/coming-soon', location.origin);
-      if (SUPPORTED.includes(lang)) u.searchParams.set('lang', lang);
-      wlCta.href = u.toString();
+      if (SUPPORTED.includes(lang)) wlCta.href = ajseeLocalizeInternalHref(u.pathname + u.search + u.hash, lang);
     } catch {
       /* noop */
     }
@@ -3469,8 +3523,7 @@ function updateHomeCtasWithLang() {
   if (demoCta) {
     try {
       const u = new URL(demoCta.getAttribute('href') || demoCta.href || '/coming-soon', location.origin);
-      u.searchParams.set('lang', lang);
-      demoCta.href = u.toString();
+      demoCta.href = ajseeLocalizeInternalHref(u.pathname + u.search + u.hash, lang);
     } catch {
       /* noop */
     }

--- a/src/nav-core.js
+++ b/src/nav-core.js
@@ -16,6 +16,83 @@ const qsa = (s, r = document) => Array.from(r.querySelectorAll(s));
 const SUPPORTED_LANGS = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
 const LANG_KEY = 'ajsee.lang';
 
+/* AJSEE language URL helpers: canonical path-prefix URLs, no runtime ?lang links. */
+const AJSEE_CANONICAL_LANGS = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+
+function ajseeCanonicalLang(value) {
+  const lang = String(value || '').trim().toLowerCase().slice(0, 2);
+  return AJSEE_CANONICAL_LANGS.includes(lang) ? lang : 'cs';
+}
+
+function ajseePathLang(pathname = window.location.pathname) {
+  const match = String(pathname || '').match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+  return match ? ajseeCanonicalLang(match[1]) : '';
+}
+
+function ajseeStripLangPrefix(pathname = '/') {
+  let path = String(pathname || '/');
+  path = path.replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+  if (!path) path = '/';
+  if (!path.startsWith('/')) path = '/' + path;
+  return path;
+}
+
+function ajseeBuildLocalizedPath(pathname = '/', lang = 'cs') {
+  const targetLang = ajseeCanonicalLang(lang);
+  let path = ajseeStripLangPrefix(pathname || '/');
+
+  path = path.replace(/\/index\.html$/i, '/');
+  path = path.replace(/\.html$/i, '');
+  path = path.replace(/\/{2,}/g, '/');
+
+  if (!path.startsWith('/')) path = '/' + path;
+  if (path !== '/' && !path.endsWith('/')) path += '/';
+
+  return targetLang === 'cs'
+    ? path
+    : '/' + targetLang + (path === '/' ? '/' : path);
+}
+
+function ajseeLocalizedUrlForLang(lang, href = window.location.href) {
+  const targetLang = ajseeCanonicalLang(lang);
+
+  try {
+    const url = new URL(href, window.location.origin);
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, targetLang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return targetLang === 'cs' ? '/' : '/' + targetLang + '/';
+  }
+}
+
+function ajseeLocalizeInternalHref(rawHref, lang) {
+  if (!rawHref) return rawHref;
+  if (String(rawHref).startsWith('#')) return rawHref;
+  if (/^(mailto:|tel:|javascript:)/i.test(String(rawHref))) return rawHref;
+  if (/^https?:\/\//i.test(String(rawHref)) && !String(rawHref).startsWith(window.location.origin)) return rawHref;
+
+  try {
+    const url = new URL(rawHref, window.location.origin);
+    if (url.origin !== window.location.origin) return rawHref;
+
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, lang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return rawHref;
+  }
+}
+
+
 function normalizeLang(x) {
   const v = String(x || '').trim().toLowerCase();
   return SUPPORTED_LANGS.includes(v) ? v : null;
@@ -31,9 +108,8 @@ function getStoredLang() {
 
 function detectLangSmart(fallback = 'cs') {
   const urlLang = normalizeLang(new URLSearchParams(location.search).get('lang'));
-  const stored = getStoredLang();
-  const htmlLang = normalizeLang(document.documentElement.getAttribute('lang'));
-  return urlLang || stored || htmlLang || fallback;
+  const pathLang = ajseePathLang(location.pathname);
+  return urlLang || pathLang || normalizeLang(fallback) || 'cs';
 }
 
 function persistLangOnly(lang) {
@@ -48,6 +124,47 @@ function onHomePage() {
   return location.pathname === '/' || location.pathname.endsWith('index.html');
 }
 
+function navPathWithoutLangPrefix(rawHref = '') {
+  const raw = String(rawHref || '').trim();
+
+  if (!raw) return '';
+  if (raw.startsWith('#')) return raw.toLowerCase();
+
+  try {
+    const u = new URL(raw, window.location.origin);
+
+    if (u.origin !== window.location.origin) return '';
+
+    let path = String(u.pathname || '/').toLowerCase();
+
+    path = path.replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+    path = path.replace(/\/index\.html$/i, '/');
+    path = path.replace(/\.html$/i, '');
+    path = path.replace(/\/+$/g, '') || '/';
+
+    return path;
+  } catch {
+    let path = raw.split('?')[0].split('#')[0].toLowerCase();
+
+    path = path.replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+    path = path.replace(/\/index\.html$/i, '/');
+    path = path.replace(/\.html$/i, '');
+    path = path.replace(/\/+$/g, '') || '/';
+
+    return path;
+  }
+}
+
+function isFaqHref(rawHref = '') {
+  const raw = String(rawHref || '').trim().toLowerCase();
+  return raw.endsWith('#faq') || navPathWithoutLangPrefix(rawHref) === '/faq';
+}
+
+function isContactHref(rawHref = '') {
+  const raw = String(rawHref || '').trim().toLowerCase();
+  return raw.endsWith('#contact') || navPathWithoutLangPrefix(rawHref) === '/contact';
+}
+
 function updateHeaderOffset() {
   const header = qs('.site-header');
   const h = header ? Math.ceil(header.getBoundingClientRect().height) : 80;
@@ -56,30 +173,7 @@ function updateHeaderOffset() {
 }
 
 function setLangOnInternalHref(rawHref, lang) {
-  const l = normalizeLang(lang) || 'cs';
-  if (!rawHref) return rawHref;
-
-  // hash-only nech
-  if (rawHref.startsWith('#')) return rawHref;
-
-  // mailto/tel/js/external
-  if (/^(mailto:|tel:|javascript:)/i.test(rawHref)) return rawHref;
-  if (/^https?:\/\//i.test(rawHref)) return rawHref;
-
-  let u;
-  try {
-    u = new URL(rawHref, window.location.origin);
-  } catch {
-    return rawHref;
-  }
-
-  if (u.origin !== window.location.origin) return rawHref;
-
-  if (l === 'cs') u.searchParams.delete('lang');
-  else u.searchParams.set('lang', l);
-
-  const search = u.searchParams.toString();
-  return u.pathname + (search ? `?${search}` : '') + (u.hash || '');
+  return ajseeLocalizeInternalHref(rawHref, lang);
 }
 
 // Aktivace aktivní položky v hlavním menu
@@ -128,78 +222,63 @@ function ensureFaqNavLink() {
   const nav = qs('.main-nav');
   if (!nav) return;
 
-  const links = Array.from(nav.querySelectorAll('a'));
-  const alreadyHasFaq = links.some((a) => {
-    const raw = (a.getAttribute('href') || '').toLowerCase();
-    const h = raw.split('?')[0];
-    return /(^|\/)faq(\.html)?$/.test(h) || raw.endsWith('#faq');
-  });
-  if (alreadyHasFaq) return;
-
-  const proto = nav.querySelector('a[href*="contact"]') || nav.querySelector('a');
-
-  const a = document.createElement('a');
-  if (proto) a.className = proto.className;
-  a.setAttribute('data-i18n-key', 'nav-faq');
-  a.textContent = window.translations?.['nav-faq'] || 'FAQ';
-  a.href = '/faq';
-
-  const contact = nav.querySelector('a[href*="contact"], a[href$="#contact"]');
-  const useList = !!nav.querySelector('li > a');
-  const nodeToInsert = useList
-    ? (() => {
-        const li = document.createElement('li');
-        li.appendChild(a);
-        return li;
-      })()
-    : a;
-
-  const contactItem = contact?.closest('li') || contact;
-  if (contactItem && contactItem.parentElement) {
-    contactItem.parentElement.insertBefore(nodeToInsert, contactItem);
-  } else {
-    (useList ? (nav.querySelector('ul') || nav) : nav).appendChild(nodeToInsert);
-  }
+  // Důležité:
+  // FAQ už má být ve statickém HTML / localized buildu.
+  // Nevkládáme ho za běhu, protože to na /en/... stránkách způsobovalo
+  // duplicitní FAQ a layout shift v menu.
+  normalizeFaqInNav(detectLangSmart('cs'));
 }
 
 function normalizeFaqInNav(lang) {
   const nav = qs('.main-nav');
   if (!nav) return;
 
-  const faqLinks = Array.from(nav.querySelectorAll('a')).filter((a) => {
-    const raw = (a.getAttribute('href') || '').toLowerCase();
-    const base = raw.split('?')[0];
-    return /(^|\/)faq(\.html)?$/.test(base) || raw.endsWith('#faq');
-  });
+  const faqLinks = Array.from(nav.querySelectorAll('a')).filter((a) =>
+    isFaqHref(a.getAttribute('href') || '')
+  );
+
   if (faqLinks.length === 0) return;
 
-  let keep = faqLinks.find((a) =>
-    /(^|\/)faq(\.html)?($|\?)/.test((a.getAttribute('href') || '').toLowerCase())
-  );
-  if (!keep) keep = faqLinks[0];
+  const keep = faqLinks[0];
+  const targetHref = setLangOnInternalHref('/faq', lang);
 
-  const target = '/faq';
-  keep.setAttribute('href', setLangOnInternalHref(target, lang));
+  if (keep.getAttribute('href') !== targetHref) {
+    keep.setAttribute('href', targetHref);
+  }
 
-  faqLinks.forEach((a) => {
-    if (a !== keep) (a.closest('li') || a).remove();
+  faqLinks.slice(1).forEach((a) => {
+    (a.closest('li') || a).remove();
   });
 
-  const contact = nav.querySelector('a[href*="contact"], a[href$="#contact"]');
+  const contact = Array.from(nav.querySelectorAll('a')).find((a) =>
+    isContactHref(a.getAttribute('href') || '') ||
+    String(a.getAttribute('href') || '').toLowerCase().includes('#contact')
+  );
+
   const keepItem = keep.closest('li') || keep;
   const contactItem = contact?.closest('li') || contact;
-  if (contactItem && contactItem.parentElement && keepItem !== contactItem.previousSibling) {
+
+  const faqAlreadyBeforeContact =
+    contactItem &&
+    keepItem &&
+    keepItem.parentElement === contactItem.parentElement &&
+    keepItem.nextElementSibling === contactItem;
+
+  if (contactItem && contactItem.parentElement && !faqAlreadyBeforeContact) {
     contactItem.parentElement.insertBefore(keepItem, contactItem);
   }
 }
 
-// Doplnění ?lang= do odkazů v menu + cs bez parametru
+// Doplnění jazykového prefixu do odkazů v menu + CS bez prefixu
 function updateMenuLinksWithLang(lang) {
   const l = normalizeLang(lang) || 'cs';
 
   qsa('.main-nav a').forEach((link) => {
     let href = link.getAttribute('href') || '';
-    if (!href || href.startsWith('mailto:') || href.startsWith('http')) return;
+
+    if (!href) return;
+    if (href.startsWith('mailto:') || href.startsWith('tel:') || href.startsWith('javascript:')) return;
+    if (/^https?:\/\//i.test(href) && !href.startsWith(window.location.origin)) return;
 
     const lower = href.toLowerCase();
 
@@ -207,14 +286,15 @@ function updateMenuLinksWithLang(lang) {
       href = '/#blog';
     } else if (lower.endsWith('#contact')) {
       href = '/#contact';
-    } else if (lower.endsWith('#faq')) {
-      href = '/faq';
-    } else if (/\/faq(\.html)?($|\?)/i.test(lower)) {
+    } else if (isFaqHref(href)) {
       href = '/faq';
     }
 
-    href = setLangOnInternalHref(href, l);
-    link.setAttribute('href', href);
+    const nextHref = setLangOnInternalHref(href, l);
+
+    if (link.getAttribute('href') !== nextHref) {
+      link.setAttribute('href', nextHref);
+    }
   });
 }
 
@@ -324,7 +404,8 @@ export function initNav({ lang = null } = {}) {
 
       const isHome = onHomePage();
       if (!isHome) {
-        window.location.href = (currentLang === 'cs') ? '/' : `/?lang=${currentLang}`;
+        const navLang = detectLangSmart('cs');
+        window.location.href = ajseeLocalizeInternalHref('/', navLang);
         return;
       }
 

--- a/src/utils/lang-dropdown.js
+++ b/src/utils/lang-dropdown.js
@@ -17,6 +17,83 @@ const SUPPORTED_LANGS = Object.keys(LANG_META);
 const STORAGE_KEY = 'ajsee.lang';
 const COOKIE_KEY = 'aj_lang';
 
+/* AJSEE language URL helpers: canonical path-prefix URLs, no runtime ?lang links. */
+const AJSEE_CANONICAL_LANGS = ['cs', 'en', 'de', 'sk', 'pl', 'hu'];
+
+function ajseeCanonicalLang(value) {
+  const lang = String(value || '').trim().toLowerCase().slice(0, 2);
+  return AJSEE_CANONICAL_LANGS.includes(lang) ? lang : 'cs';
+}
+
+function ajseePathLang(pathname = window.location.pathname) {
+  const match = String(pathname || '').match(/^\/(cs|en|de|sk|pl|hu)(?:\/|$)/i);
+  return match ? ajseeCanonicalLang(match[1]) : '';
+}
+
+function ajseeStripLangPrefix(pathname = '/') {
+  let path = String(pathname || '/');
+  path = path.replace(/^\/(cs|en|de|sk|pl|hu)(?=\/|$)/i, '');
+  if (!path) path = '/';
+  if (!path.startsWith('/')) path = '/' + path;
+  return path;
+}
+
+function ajseeBuildLocalizedPath(pathname = '/', lang = 'cs') {
+  const targetLang = ajseeCanonicalLang(lang);
+  let path = ajseeStripLangPrefix(pathname || '/');
+
+  path = path.replace(/\/index\.html$/i, '/');
+  path = path.replace(/\.html$/i, '');
+  path = path.replace(/\/{2,}/g, '/');
+
+  if (!path.startsWith('/')) path = '/' + path;
+  if (path !== '/' && !path.endsWith('/')) path += '/';
+
+  return targetLang === 'cs'
+    ? path
+    : '/' + targetLang + (path === '/' ? '/' : path);
+}
+
+function ajseeLocalizedUrlForLang(lang, href = window.location.href) {
+  const targetLang = ajseeCanonicalLang(lang);
+
+  try {
+    const url = new URL(href, window.location.origin);
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, targetLang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return targetLang === 'cs' ? '/' : '/' + targetLang + '/';
+  }
+}
+
+function ajseeLocalizeInternalHref(rawHref, lang) {
+  if (!rawHref) return rawHref;
+  if (String(rawHref).startsWith('#')) return rawHref;
+  if (/^(mailto:|tel:|javascript:)/i.test(String(rawHref))) return rawHref;
+  if (/^https?:\/\//i.test(String(rawHref)) && !String(rawHref).startsWith(window.location.origin)) return rawHref;
+
+  try {
+    const url = new URL(rawHref, window.location.origin);
+    if (url.origin !== window.location.origin) return rawHref;
+
+    url.searchParams.delete('lang');
+    url.searchParams.delete('locale');
+    url.searchParams.delete('hl');
+    url.pathname = ajseeBuildLocalizedPath(url.pathname, lang);
+
+    const search = url.searchParams.toString();
+    return url.pathname + (search ? '?' + search : '') + (url.hash || '');
+  } catch {
+    return rawHref;
+  }
+}
+
+
 const wiredRoots = new WeakSet();
 
 let documentClickWired = false;
@@ -90,30 +167,20 @@ function detectLang() {
     fromUrl = null;
   }
 
-  const fromPath = getPathLang();
-  const fromCookie = getCookieLang();
-  const fromStorage = getStoredLang();
-  const fromHtml = normalizeLang(document.documentElement.getAttribute('lang'));
+  const fromPath = ajseePathLang(window.location.pathname);
 
-  // Sjednocené pořadí s main.js:
-  // URL -> path -> cookie -> localStorage -> <html lang> -> cs
-  return fromUrl || fromPath || fromCookie || fromStorage || fromHtml || 'cs';
+  // Canonical rule: URL/query decides language. Non-prefixed pages are always Czech.
+  return fromUrl || fromPath || 'cs';
 }
 
 function updateUrlLang(lang) {
   const normalized = normalizeLang(lang) || 'cs';
 
   try {
-    const url = new URL(window.location.href);
+    const nextUrl = ajseeLocalizedUrlForLang(normalized);
 
-    if (normalized === 'cs') {
-      url.searchParams.delete('lang');
-    } else {
-      url.searchParams.set('lang', normalized);
-    }
-
-    if (url.toString() !== window.location.href) {
-      window.history.replaceState({}, '', url.toString());
+    if (nextUrl !== (window.location.pathname + window.location.search + window.location.hash)) {
+      window.history.replaceState({}, '', nextUrl);
     }
   } catch {
     /* noop */
@@ -303,11 +370,11 @@ function setSelectedUIForRoot(root, lang) {
     root.querySelector('.lang-current-flag') ||
     root.querySelector('img.flag');
 
-  if (currentLabel) currentLabel.textContent = meta.label;
+  if (currentLabel && currentLabel.textContent !== meta.label) currentLabel.textContent = meta.label;
 
   if (currentFlag) {
-    currentFlag.src = meta.flag;
-    currentFlag.alt = meta.label;
+    if (currentFlag.getAttribute('src') !== meta.flag) currentFlag.setAttribute('src', meta.flag);
+    if (currentFlag.getAttribute('alt') !== meta.label) currentFlag.setAttribute('alt', meta.label);
   }
 
   root.querySelectorAll('.lang-btn[data-lang]').forEach((btn) => {


### PR DESCRIPTION
## Summary
- Adds static localized routes for EN, DE, SK, PL and HU.
- Keeps Czech as the default root version.
- Generates localized HTML pages after Vite build.
- Rewrites internal links, canonical links and hreflang alternates.
- Fixes localized static labels including homepage blog CTA and logo accessibility label.

## Validation
- npm run build ✅
- npm run seo:smoke ✅
- Localized pages generated ✅
- EN homepage visible/a11y Czech leak check ✅

## Notes
This replaces the previous runtime-only `?lang=` approach with static language-prefixed routes such as `/en/`, `/de/`, `/sk/`, `/pl/`, `/hu/`.