### PR TITLE
Generate localized sitemap and noindex blog detail fallback

### DIFF
--- a/blog-detail.html
+++ b/blog-detail.html
@@ -11,7 +11,7 @@
     content="Přečti si článek z blogu AJSEE o koncertech, festivalech, sportovních událostech, cestování a plánování zážitků."
   />
 
-<meta name="robots" content="index, follow" />
+<meta name="robots" content="noindex, follow" />
   <meta name="theme-color" content="#0077cc" />
 
   <!-- Favicona -->

--- a/package.json
+++ b/package.json
@@ -1,51 +1,52 @@
 {
-  "name": "ajsee-site",
-  "version": "1.0.0",
-  "description": "AJSEE web – moderní responzivní vícejazyčný frontend",
-  "author": "Tým AJSEE",
-  "license": "MIT",
-  "type": "module",
-  "engines": {
-    "node": "20.x"
-  },
-  "scripts": {
-    "svgo:mg": "svgo -f public/images/microguides/seating-map -o public/images/microguides/seating-map --multipass",
-    "mg:build": "node scripts/build-mg.mjs",
-    "mg:copy-json": "npx cpy-cli \"content/microguides/*.json\" public/content/microguides",
-    "predev": "npx cpy-cli src/locales/*.json public/locales --parents && npm run svgo:mg && npm run mg:build && npm run mg:copy-json && npm run blog:build",
-    "dev": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite",
-    "dev:netlify": "netlify dev",
-    "dev:ntl": "netlify dev",
-    "start": "npm run dev",
-    "prebuild": "npx cpy-cli src/locales/*.json public/locales --parents && npm run svgo:mg && npm run mg:build && npm run mg:copy-json && npm run blog:build",
-    "build": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite build && node scripts/build-localized-pages.cjs",
-    "preview": "vite preview",
-    "webpack:dev": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api webpack serve --mode development",
-    "webpack:build": "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api webpack --mode production",
-    "check:locales": "node scripts/check-locales.js",
-    "blog:build": "node scripts/build-blog.mjs",
-    "seo:smoke": "node scripts/seo-smoke.mjs"
-  },
-  "devDependencies": {
-    "@squoosh/cli": "^0.7.1",
-    "babel-loader": "^9.1.3",
-    "cpy-cli": "^5.0.0",
-    "cross-env": "^7.0.3",
-    "css-loader": "^6.9.1",
-    "cwebp-bin": "^8.0.0",
-    "mini-css-extract-plugin": "^2.7.6",
-    "netlify-cli": "^23.9.1",
-    "sass-embedded": "^1.90.0",
-    "sass-loader": "^13.3.2",
-    "sharp-cli": "^5.2.0",
-    "svgo": "^4.0.0",
-    "vite": "5.4.19",
-    "vite-plugin-static-copy": "^3.1.1",
-    "webpack": "^5.89.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.2.2"
-  },
-  "dependencies": {
-    "node-fetch": "^2.6.9"
-  }
+    "name":  "ajsee-site",
+    "version":  "1.0.0",
+    "description":  "AJSEE web – moderní responzivní vícejazyčný frontend",
+    "author":  "Tým AJSEE",
+    "license":  "MIT",
+    "type":  "module",
+    "engines":  {
+                    "node":  "20.x"
+                },
+    "scripts":  {
+                    "svgo:mg":  "svgo -f public/images/microguides/seating-map -o public/images/microguides/seating-map --multipass",
+                    "mg:build":  "node scripts/build-mg.mjs",
+                    "mg:copy-json":  "npx cpy-cli \"content/microguides/*.json\" public/content/microguides",
+                    "predev":  "npx cpy-cli src/locales/*.json public/locales --parents \u0026\u0026 npm run svgo:mg \u0026\u0026 npm run mg:build \u0026\u0026 npm run mg:copy-json \u0026\u0026 npm run blog:build",
+                    "dev":  "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite",
+                    "dev:netlify":  "netlify dev",
+                    "dev:ntl":  "netlify dev",
+                    "start":  "npm run dev",
+                    "prebuild":  "npx cpy-cli src/locales/*.json public/locales --parents \u0026\u0026 npm run svgo:mg \u0026\u0026 npm run mg:build \u0026\u0026 npm run mg:copy-json \u0026\u0026 npm run blog:build",
+                    "build":  "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api vite build \u0026\u0026 node scripts/build-localized-pages.cjs \u0026\u0026 node scripts/generate-sitemap.cjs",
+                    "preview":  "vite preview",
+                    "webpack:dev":  "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api webpack serve --mode development",
+                    "webpack:build":  "cross-env SASS_SILENCE_DEPRECATIONS=legacy-js-api webpack --mode production",
+                    "check:locales":  "node scripts/check-locales.js",
+                    "blog:build":  "node scripts/build-blog.mjs",
+                    "seo:smoke":  "node scripts/seo-smoke.mjs",
+                    "sitemap:build":  "node scripts/generate-sitemap.cjs"
+                },
+    "devDependencies":  {
+                            "@squoosh/cli":  "^0.7.1",
+                            "babel-loader":  "^9.1.3",
+                            "cpy-cli":  "^5.0.0",
+                            "cross-env":  "^7.0.3",
+                            "css-loader":  "^6.9.1",
+                            "cwebp-bin":  "^8.0.0",
+                            "mini-css-extract-plugin":  "^2.7.6",
+                            "netlify-cli":  "^23.9.1",
+                            "sass-embedded":  "^1.90.0",
+                            "sass-loader":  "^13.3.2",
+                            "sharp-cli":  "^5.2.0",
+                            "svgo":  "^4.0.0",
+                            "vite":  "5.4.19",
+                            "vite-plugin-static-copy":  "^3.1.1",
+                            "webpack":  "^5.89.0",
+                            "webpack-cli":  "^5.1.4",
+                            "webpack-dev-server":  "^5.2.2"
+                        },
+    "dependencies":  {
+                         "node-fetch":  "^2.6.9"
+                     }
 }

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ajsee.cz/</loc>
@@ -8,8 +8,78 @@
   </url>
 
   <url>
+    <loc>https://ajsee.cz/de/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://ajsee.cz/events</loc>
     <lastmod>2026-05-01</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/events/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/events/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/events/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/events/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/events/</loc>
+    <lastmod>2026-05-10</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
@@ -22,8 +92,78 @@
   </url>
 
   <url>
+    <loc>https://ajsee.cz/de/accommodation/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/accommodation/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/accommodation/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/accommodation/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/accommodation/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://ajsee.cz/partners</loc>
     <lastmod>2026-05-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/partners/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/partners/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/partners/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/partners/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/partners/</loc>
+    <lastmod>2026-05-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -36,11 +176,82 @@
   </url>
 
   <url>
+    <loc>https://ajsee.cz/de/about/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/about/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/about/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/about/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/about/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://ajsee.cz/blog</loc>
     <lastmod>2026-05-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/blog/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/blog/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/blog/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/blog/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/blog/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
   <url>
     <loc>https://ajsee.cz/blog/koncert-coldplay-praha-2025/</loc>
     <lastmod>2025-06-11</lastmod>
@@ -70,21 +281,92 @@
   </url>
 
   <url>
+    <loc>https://ajsee.cz/de/faq/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/faq/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/faq/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/faq/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/faq/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
     <loc>https://ajsee.cz/microguides/</loc>
     <lastmod>2026-05-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
+
   <url>
-    <loc>https://ajsee.cz/microguides/seating-map/</loc>
-    <lastmod>2025-08-22</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
+    <loc>https://ajsee.cz/de/microguides/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/microguides/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/microguides/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/microguides/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/microguides/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://ajsee.cz/microguides/fees-refund/</loc>
     <lastmod>2025-08-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/microguides/seating-map/</loc>
+    <lastmod>2025-08-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
@@ -116,7 +398,224 @@
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
-  
+
+  <url>
+    <loc>https://ajsee.cz/de/microguides/fees-refund/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/microguides/seating-map/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/microguides/set-times-merch/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/microguides/stadium-entry/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/microguides/theatre-last-minute/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/microguides/when-to-buy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/microguides/fees-refund/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/microguides/seating-map/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/microguides/set-times-merch/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/microguides/stadium-entry/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/microguides/theatre-last-minute/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/microguides/when-to-buy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/microguides/fees-refund/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/microguides/seating-map/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/microguides/set-times-merch/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/microguides/stadium-entry/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/microguides/theatre-last-minute/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/microguides/when-to-buy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/microguides/fees-refund/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/microguides/seating-map/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/microguides/set-times-merch/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/microguides/stadium-entry/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/microguides/theatre-last-minute/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/microguides/when-to-buy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/microguides/fees-refund/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/microguides/seating-map/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/microguides/set-times-merch/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/microguides/stadium-entry/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/microguides/theatre-last-minute/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/microguides/when-to-buy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/cookies-policy</loc>
+    <lastmod>2026-05-01</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
   <url>
     <loc>https://ajsee.cz/privacy-policy</loc>
     <lastmod>2026-05-01</lastmod>
@@ -125,8 +624,71 @@
   </url>
 
   <url>
-    <loc>https://ajsee.cz/cookies-policy</loc>
-    <lastmod>2026-05-01</lastmod>
+    <loc>https://ajsee.cz/de/cookies-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/de/privacy-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/cookies-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/en/privacy-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/cookies-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/hu/privacy-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/cookies-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/pl/privacy-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/cookies-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://ajsee.cz/sk/privacy-policy/</loc>
+    <lastmod>2026-05-10</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/scripts/generate-sitemap.cjs
+++ b/scripts/generate-sitemap.cjs
@@ -1,0 +1,269 @@
+﻿const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = process.cwd();
+const DIST = path.join(ROOT, 'dist');
+const PUBLIC_SITEMAP = path.join(ROOT, 'public', 'sitemap.xml');
+const DIST_SITEMAP = path.join(DIST, 'sitemap.xml');
+
+const ORIGIN = 'https://ajsee.cz';
+const LANG_PREFIX_RE = /^\/(en|de|sk|pl|hu)(?=\/|$)/i;
+
+function todayISO() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function walk(dir, out = []) {
+  if (!fs.existsSync(dir)) return out;
+
+  for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, item.name);
+
+    if (item.isDirectory()) {
+      walk(full, out);
+      continue;
+    }
+
+    if (item.isFile() && item.name.toLowerCase().endsWith('.html')) {
+      out.push(full);
+    }
+  }
+
+  return out;
+}
+
+function read(file) {
+  return fs.readFileSync(file, 'utf8');
+}
+
+function writeIfChanged(file, content) {
+  const prev = fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+  if (prev === content) return false;
+
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content, 'utf8');
+  return true;
+}
+
+function getAttr(tag, name) {
+  const re = new RegExp(`\\b${name}\\s*=\\s*["']([^"']*)["']`, 'i');
+  return tag.match(re)?.[1] || '';
+}
+
+function robotsContent(html) {
+  const tag = html.match(/<meta\b(?=[^>]*\bname=["']robots["'])[^>]*>/i)?.[0] || '';
+  return getAttr(tag, 'content').toLowerCase();
+}
+
+function isNoindex(html) {
+  return /\bnoindex\b/i.test(robotsContent(html));
+}
+
+function canonicalHref(html) {
+  const tag = html.match(/<link\b(?=[^>]*\brel=["']canonical["'])[^>]*>/i)?.[0] || '';
+  return getAttr(tag, 'href').trim();
+}
+
+function normalizeCanonical(raw) {
+  if (!raw) return '';
+
+  try {
+    const url = new URL(raw, ORIGIN);
+    if (url.origin !== ORIGIN) return '';
+
+    url.hash = '';
+    url.search = '';
+
+    let pathname = url.pathname || '/';
+    pathname = pathname.replace(/\/index\.html$/i, '/');
+
+    if (pathname !== '/' && pathname.endsWith('/')) {
+      // Czech canonical routes in project intentionally use no trailing slash for main pages,
+      // while localized routes and generated content often keep slash. Preserve what canonical says.
+    }
+
+    return url.origin + pathname;
+  } catch {
+    return '';
+  }
+}
+
+function canonicalPath(url) {
+  try {
+    return new URL(url).pathname || '/';
+  } catch {
+    return '';
+  }
+}
+
+function isLocalizedBlogArticle(pathname) {
+  return /^\/(en|de|sk|pl|hu)\/blog\/[^/]+\/?$/i.test(pathname);
+}
+
+function shouldInclude(url) {
+  const pathname = canonicalPath(url);
+
+  if (!pathname) return false;
+
+  // Technical / fallback / non-search pages.
+  if (/\/admin(\/|$)/i.test(pathname)) return false;
+  if (/\/blog-detail\/?$/i.test(pathname)) return false;
+  if (/\/coming-soon(\/|$)/i.test(pathname)) return false;
+  if (/\/thank-you\/?$/i.test(pathname)) return false;
+
+  // Important: localized blog article clones currently reuse Czech article content.
+  // Keep only Czech blog article URLs in sitemap until real translated article content exists.
+  if (isLocalizedBlogArticle(pathname)) return false;
+
+  return true;
+}
+
+function readExistingLastmods() {
+  const map = new Map();
+
+  for (const file of [PUBLIC_SITEMAP, DIST_SITEMAP]) {
+    if (!fs.existsSync(file)) continue;
+
+    const xml = fs.readFileSync(file, 'utf8');
+    const blocks = xml.match(/<url>[\s\S]*?<\/url>/g) || [];
+
+    for (const block of blocks) {
+      const loc = block.match(/<loc>([\s\S]*?)<\/loc>/i)?.[1]?.trim();
+      const lastmod = block.match(/<lastmod>([\s\S]*?)<\/lastmod>/i)?.[1]?.trim();
+
+      if (loc && lastmod && !map.has(loc)) {
+        map.set(loc, lastmod);
+      }
+    }
+  }
+
+  return map;
+}
+
+function priorityFor(pathname) {
+  const clean = pathname.replace(/\/+$/g, '') || '/';
+  const withoutLang = clean.replace(LANG_PREFIX_RE, '') || '/';
+
+  if (clean === '/') return '1.0';
+  if (/^\/(en|de|sk|pl|hu)$/i.test(clean)) return '0.8';
+
+  if (withoutLang === '/events') return '0.9';
+  if (withoutLang === '/accommodation') return '0.8';
+  if (withoutLang === '/partners') return '0.8';
+  if (withoutLang === '/about') return '0.7';
+  if (withoutLang === '/blog') return '0.7';
+  if (/^\/blog\/[^/]+$/i.test(withoutLang)) return '0.6';
+  if (withoutLang === '/faq') return '0.6';
+  if (withoutLang === '/microguides') return '0.6';
+  if (/^\/microguides\/[^/]+$/i.test(withoutLang)) return '0.5';
+  if (withoutLang === '/privacy-policy' || withoutLang === '/cookies-policy') return '0.3';
+
+  return '0.5';
+}
+
+function changefreqFor(pathname) {
+  const clean = pathname.replace(/\/+$/g, '') || '/';
+  const withoutLang = clean.replace(LANG_PREFIX_RE, '') || '/';
+
+  if (withoutLang === '/') return 'weekly';
+  if (withoutLang === '/events') return 'daily';
+  if (withoutLang === '/blog') return 'weekly';
+  if (withoutLang === '/microguides') return 'weekly';
+  if (withoutLang === '/privacy-policy' || withoutLang === '/cookies-policy') return 'yearly';
+
+  return 'monthly';
+}
+
+function sortRank(url) {
+  const pathname = canonicalPath(url);
+  const clean = pathname.replace(/\/+$/g, '') || '/';
+  const withoutLang = clean.replace(LANG_PREFIX_RE, '') || '/';
+  const langWeight = LANG_PREFIX_RE.test(clean) ? 1 : 0;
+
+  let section = 90;
+
+  if (withoutLang === '/') section = 0;
+  else if (withoutLang === '/events') section = 10;
+  else if (withoutLang === '/accommodation') section = 20;
+  else if (withoutLang === '/partners') section = 30;
+  else if (withoutLang === '/about') section = 40;
+  else if (withoutLang === '/blog') section = 50;
+  else if (/^\/blog\/[^/]+$/i.test(withoutLang)) section = 55;
+  else if (withoutLang === '/faq') section = 60;
+  else if (withoutLang === '/microguides') section = 70;
+  else if (/^\/microguides\/[^/]+$/i.test(withoutLang)) section = 75;
+  else if (withoutLang === '/privacy-policy' || withoutLang === '/cookies-policy') section = 95;
+
+  return `${String(section).padStart(3, '0')}-${langWeight}-${url}`;
+}
+
+function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function buildSitemap(urls, lastmods) {
+  const fallbackLastmod = todayISO();
+
+  const body = urls.map((url) => {
+    const pathname = canonicalPath(url);
+    const lastmod = lastmods.get(url) || fallbackLastmod;
+
+    return [
+      '  <url>',
+      `    <loc>${escapeXml(url)}</loc>`,
+      `    <lastmod>${escapeXml(lastmod)}</lastmod>`,
+      `    <changefreq>${changefreqFor(pathname)}</changefreq>`,
+      `    <priority>${priorityFor(pathname)}</priority>`,
+      '  </url>'
+    ].join('\n');
+  }).join('\n\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    body,
+    '</urlset>',
+    ''
+  ].join('\n');
+}
+
+function main() {
+  if (!fs.existsSync(DIST)) {
+    throw new Error('dist neexistuje. Nejdřív spusť npm run build.');
+  }
+
+  const lastmods = readExistingLastmods();
+  const urls = new Map();
+
+  for (const file of walk(DIST)) {
+    const html = read(file);
+
+    if (isNoindex(html)) continue;
+
+    const canonical = normalizeCanonical(canonicalHref(html));
+    if (!canonical) continue;
+    if (!shouldInclude(canonical)) continue;
+
+    if (!urls.has(canonical)) {
+      urls.set(canonical, path.relative(DIST, file));
+    }
+  }
+
+  const sortedUrls = [...urls.keys()].sort((a, b) => sortRank(a).localeCompare(sortRank(b)));
+  const xml = buildSitemap(sortedUrls, lastmods);
+
+  const wrotePublic = writeIfChanged(PUBLIC_SITEMAP, xml);
+  const wroteDist = writeIfChanged(DIST_SITEMAP, xml);
+
+  console.log('AJSEE sitemap generated');
+  console.log('============================================================');
+  console.log(`URLs: ${sortedUrls.length}`);
+  console.log(`public/sitemap.xml: ${wrotePublic ? 'updated' : 'unchanged'}`);
+  console.log(`dist/sitemap.xml: ${wroteDist ? 'updated' : 'unchanged'}`);
+}
+
+main();


### PR DESCRIPTION
Adds an automated sitemap generator for localized static pages.

Changes:
- Generates sitemap.xml from indexable canonical pages after localized build
- Includes localized EN/DE/SK/PL/HU pages in sitemap
- Excludes noindex pages and blog-detail fallback pages
- Sets blog-detail fallback pages to noindex, follow
- Keeps real generated blog articles indexable