### PR TITLE
Feature/smsticket city subsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ dist-ssr
 .env
 # Local AJSEE debug/archive files
 _local-debug-archive/
+
+# Generated SMS Ticket city subset feeds
+public/data/smsticket-events-*.json

--- a/scripts/sync-smsticket-events.mjs
+++ b/scripts/sync-smsticket-events.mjs
@@ -12,7 +12,20 @@ import path from 'node:path';
 
 const SMSTICKET_API_URL = 'https://www.smsticket.cz/api/public/v1.1/events';
 const OUT_FILE = path.resolve('public/data/smsticket-events.json');
+const OUT_DIR = path.dirname(OUT_FILE);
 const AFFILIATE_PARAM = 'a_box=d4n78jy6';
+
+// AJSEE_SMSTICKET_CITY_SUBSETS_v1
+// Keep the full feed as the canonical fallback, but also write small city feeds
+// for explicit high-traffic city searches so the browser does not need to
+// download and parse the whole SMS Ticket dataset.
+const CITY_SUBSETS = [
+  { slug: 'praha', aliases: ['praha', 'prague'] },
+  { slug: 'brno', aliases: ['brno'] },
+  { slug: 'ostrava', aliases: ['ostrava'] },
+  { slug: 'bratislava', aliases: ['bratislava'] },
+  { slug: 'kosice', aliases: ['kosice', 'košice'] }
+];
 
 function toArray(value) {
   if (!value) return [];
@@ -270,6 +283,81 @@ function normalizeEvent(event) {
   };
 }
 
+
+function foldSubsetCity(value = '') {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getSubsetCity(event = {}) {
+  return foldSubsetCity(
+    event?.place?.city ||
+    event?.venue?.city ||
+    event?.city ||
+    ''
+  );
+}
+
+function matchesSubsetCity(event, definition) {
+  const city = getSubsetCity(event);
+
+  if (!city) return false;
+
+  return definition.aliases.some((alias) => {
+    const foldedAlias = foldSubsetCity(alias);
+
+    return (
+      city === foldedAlias ||
+      city.startsWith(foldedAlias + ' ') ||
+      city.endsWith(' ' + foldedAlias) ||
+      city.includes(' ' + foldedAlias + ' ')
+    );
+  });
+}
+
+function createSubsetPayload(payload, definition, events) {
+  return {
+    ...payload,
+    subset: {
+      type: 'city',
+      slug: definition.slug,
+      aliases: definition.aliases
+    },
+    count: events.length,
+    events
+  };
+}
+
+async function writeSmsticketPayloads(payload) {
+  await mkdir(OUT_DIR, { recursive: true });
+
+  await writeFile(OUT_FILE, JSON.stringify(payload, null, 2), 'utf8');
+
+  console.log('[smsticket] synced ' + payload.events.length + ' events -> ' + OUT_FILE);
+
+  for (const definition of CITY_SUBSETS) {
+    const subsetEvents = payload.events.filter((event) => matchesSubsetCity(event, definition));
+    const subsetFile = path.join(OUT_DIR, 'smsticket-events-' + definition.slug + '.json');
+    const subsetPayload = createSubsetPayload(payload, definition, subsetEvents);
+
+    await writeFile(subsetFile, JSON.stringify(subsetPayload, null, 2), 'utf8');
+
+    console.log(
+      '[smsticket] city subset ' +
+      definition.slug +
+      ': ' +
+      subsetEvents.length +
+      ' events -> ' +
+      subsetFile
+    );
+  }
+}
 async function readExistingFallback() {
   if (!existsSync(OUT_FILE)) return null;
 
@@ -332,10 +420,7 @@ async function main() {
       events
     };
 
-    await mkdir(path.dirname(OUT_FILE), { recursive: true });
-    await writeFile(OUT_FILE, JSON.stringify(payload, null, 2), 'utf8');
-
-    console.log(`[smsticket] synced ${events.length} events -> ${OUT_FILE}`);
+    await writeSmsticketPayloads(payload);
   } catch (error) {
     console.warn(`[smsticket] sync failed: ${error?.message || error}`);
 
@@ -346,7 +431,7 @@ async function main() {
       return;
     }
 
-    await mkdir(path.dirname(OUT_FILE), { recursive: true });
+    await mkdir(OUT_DIR, { recursive: true });
     await writeFile(
       OUT_FILE,
       JSON.stringify({

--- a/src/adapters/smsticket.js
+++ b/src/adapters/smsticket.js
@@ -10,39 +10,121 @@
 
 import { canonForInputCity } from '../city/canonical.js';
 
-const DATA_URL = '/data/smsticket-events.json';
+const DEFAULT_DATA_URL = '/data/smsticket-events.json';
 
-let cache = null;
-let cachePromise = null;
+// AJSEE_SMSTICKET_CITY_SUBSET_FEEDS_v1
+// Prefer a small city-specific static feed when the user explicitly searches
+// a supported CZ/SK city. If the subset is missing or fails to load, fall back
+// to the original full feed.
+const CITY_DATA_URLS = [
+  { url: '/data/smsticket-events-praha.json', aliases: ['praha', 'prague'] },
+  { url: '/data/smsticket-events-brno.json', aliases: ['brno'] },
+  { url: '/data/smsticket-events-ostrava.json', aliases: ['ostrava'] },
+  { url: '/data/smsticket-events-bratislava.json', aliases: ['bratislava'] },
+  { url: '/data/smsticket-events-kosice.json', aliases: ['kosice', 'košice'] }
+];
 
-async function loadSmsticketData() {
-  if (cache) return cache;
-  if (cachePromise) return cachePromise;
+const dataCache = new Map();
+const dataPromiseCache = new Map();
 
-  cachePromise = (async () => {
+function getFilterCityText(filters = {}) {
+  return String([
+    filters.city,
+    filters.cityLabel,
+    filters.location
+  ].filter(Boolean).join(' ')).trim();
+}
+
+function getCanonicalCityText(cityText = '') {
+  try {
+    const canonical = canonForInputCity(cityText);
+
+    if (!canonical) return '';
+
+    if (typeof canonical === 'string') return canonical;
+
+    return String(
+      canonical.city ||
+      canonical.name ||
+      canonical.label ||
+      canonical.value ||
+      ''
+    );
+  } catch {
+    return '';
+  }
+}
+
+function resolveSmsticketDataUrl(filters = {}) {
+  const cityText = getFilterCityText(filters);
+
+  if (!cityText) return DEFAULT_DATA_URL;
+
+  const folded = fold([
+    cityText,
+    getCanonicalCityText(cityText)
+  ].filter(Boolean).join(' '));
+
+  const match = CITY_DATA_URLS.find((definition) =>
+    definition.aliases.some((alias) => {
+      const foldedAlias = fold(alias);
+
+      return (
+        folded === foldedAlias ||
+        folded.startsWith(foldedAlias + ' ') ||
+        folded.endsWith(' ' + foldedAlias) ||
+        folded.includes(' ' + foldedAlias + ' ')
+      );
+    })
+  );
+
+  return match?.url || DEFAULT_DATA_URL;
+}
+
+async function loadSmsticketDataUrl(dataUrl = DEFAULT_DATA_URL) {
+  if (dataCache.has(dataUrl)) return dataCache.get(dataUrl);
+  if (dataPromiseCache.has(dataUrl)) return dataPromiseCache.get(dataUrl);
+
+  const promise = (async () => {
     try {
-      const response = await fetch(DATA_URL, { cache: 'default' });
+      const response = await fetch(dataUrl, { cache: 'default' });
 
       if (!response.ok) {
-        cache = [];
-        return cache;
+        dataCache.set(dataUrl, null);
+        return null;
       }
 
       const payload = await response.json();
       const events = Array.isArray(payload?.events) ? payload.events : [];
 
-      cache = events;
-      return cache;
+      dataCache.set(dataUrl, events);
+      return events;
     } catch (error) {
-      console.warn('[smsticket adapter] failed to load data:', error);
-      cache = [];
-      return cache;
+      console.warn('[smsticket adapter] failed to load data from ' + dataUrl + ':', error);
+      dataCache.set(dataUrl, null);
+      return null;
     } finally {
-      cachePromise = null;
+      dataPromiseCache.delete(dataUrl);
     }
   })();
 
-  return cachePromise;
+  dataPromiseCache.set(dataUrl, promise);
+  return promise;
+}
+
+async function loadSmsticketData(filters = {}) {
+  const primaryUrl = resolveSmsticketDataUrl(filters);
+  const primaryEvents = await loadSmsticketDataUrl(primaryUrl);
+
+  if (Array.isArray(primaryEvents)) return primaryEvents;
+
+  if (primaryUrl !== DEFAULT_DATA_URL) {
+    const fallbackEvents = await loadSmsticketDataUrl(DEFAULT_DATA_URL);
+
+    if (Array.isArray(fallbackEvents)) return fallbackEvents;
+  }
+
+  return [];
 }
 
 function fold(value = '') {
@@ -345,7 +427,7 @@ export async function fetchEvents({ filters = {} } = {}) {
   if (filters.includeSmsticket === false) return [];
   if (shouldSkipForCountry(filters)) return [];
 
-  const events = await loadSmsticketData();
+  const events = await loadSmsticketData(filters);
 
   // AJSEE_SMSTICKET_SINGLE_PASS_FILTER_v1
   // Keep the adapter result equivalent, but avoid several full-array passes


### PR DESCRIPTION
Title:
Split SMS Ticket feed into city subsets

Description:
This PR adds city-specific SMS Ticket static feed support.

Changes:
- Generates city subset feeds during smsticket sync for Praha, Brno, Ostrava, Bratislava and Košice.
- Updates SMS Ticket adapter to prefer city-specific subset feeds for explicit city searches.
- Keeps the original full smsticket-events.json as a safe fallback.
- Reduces Prague SMS Ticket payload from ~7.4 MB to ~0.95 MB in local testing.

Tested:
- Local URL: /events.html?city=Praha&cityCc=CZ
- Confirmed loaded feed: /data/smsticket-events-praha.json
- Confirmed full feed was not loaded for explicit Prague search.