### PR TITLE
Slim SMS Ticket city subset payloads

### DIFF
--- a/scripts/sync-smsticket-events.mjs
+++ b/scripts/sync-smsticket-events.mjs
@@ -321,16 +321,41 @@ function matchesSubsetCity(event, definition) {
   });
 }
 
+// AJSEE_SMSTICKET_LIGHT_CITY_SUBSETS_v1
+// City subset feeds are listing payloads. Keep the full smsticket-events.json
+// unchanged as the canonical fallback, but strip fields that are not needed for
+// event cards, city/category/date/keyword filtering, provider badges or links.
+function createLightCitySubsetEvent(event = {}) {
+  const {
+    description,
+    imageOriginal,
+    rawUrl,
+    bookingEndsAt,
+    ...lightEvent
+  } = event;
+
+  return lightEvent;
+}
+
 function createSubsetPayload(payload, definition, events) {
+  const lightEvents = events.map(createLightCitySubsetEvent);
+
   return {
     ...payload,
     subset: {
       type: 'city',
       slug: definition.slug,
-      aliases: definition.aliases
+      aliases: definition.aliases,
+      payload: 'listing-light',
+      removedFields: [
+        'description',
+        'imageOriginal',
+        'rawUrl',
+        'bookingEndsAt'
+      ]
     },
-    count: events.length,
-    events
+    count: lightEvents.length,
+    events: lightEvents
   };
 }
 


### PR DESCRIPTION
This PR reduces generated SMS Ticket city subset payloads by removing listing-noncritical fields from city feeds only.

Changes:
- Keeps full /data/smsticket-events.json unchanged as canonical fallback.
- City subset feeds now use listing-light payload.
- Removes description, imageOriginal, rawUrl and bookingEndsAt from city subset feeds.
- Keeps priceFrom, url, tickets, venue, place and category for listing/filtering.

Expected impact:
- Praha subset: ~954 KB production transfer → ~612 KB generated payload.
- Brno subset: ~858 KB → ~555 KB.
- Ostrava subset: ~139 KB → ~90 KB.