### PR TITLE
Stabilize review submission editor

### DIFF
--- a/public/review-admin/config.yml
+++ b/public/review-admin/config.yml
@@ -179,7 +179,7 @@ collections:
 
           - label: "Full review text"
             name: "body"
-            widget: "markdown"
+            widget: "text"
             required: true
             hint: "Paste the full English review here."
 


### PR DESCRIPTION
## Summary

This hotfix replaces the Decap CMS Markdown widget used for the full review text with a simpler multiline text field.

## Reason

An external contributor encountered a Decap CMS interface crash while saving a review submission:

`NotFoundError: Failed to execute 'removeChild' on 'Node'`

The submission was not saved.

## Change

- Replaced the `markdown` widget with the more stable `text` widget for the full review body.
- The editor preview remains disabled.

## Safety

- No review content was changed.
- No public website content was changed.
- The publishing workflow and public-review safeguards remain unchanged.