### PR TITLE
fix(events): group SMS Ticket ticket options

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "reviews:build": "node scripts/build-reviews.mjs",
     "review-details:build": "node scripts/build-review-details.mjs",
     "review-details:localize": "cross-env REVIEW_LOCALIZE=1 node scripts/build-review-details.mjs",
-    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs"
+    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs"
   },
   "devDependencies": {
     "@squoosh/cli": "^0.7.1",

--- a/src/adapters/smsticket.js
+++ b/src/adapters/smsticket.js
@@ -484,6 +484,315 @@ function matchesNearMe(ev, filters = {}) {
   return haversineKm(+filters.nearMeLat, +filters.nearMeLon, +lat, +lon) <= radius;
 }
 
+
+// AJSEE_SMSTICKET_TICKET_OPTIONS_v1
+function smsticketDedupeText(value) {
+  if (!value) return '';
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    return String(
+      value.cs ||
+      value.sk ||
+      value.en ||
+      Object.values(value)[0] ||
+      ''
+    );
+  }
+
+  return String(value);
+}
+
+function normalizeSmsticketOccurrencePart(value) {
+  return smsticketDedupeText(value)
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function smsticketOccurrenceTitle(event) {
+  return normalizeSmsticketOccurrencePart(
+    event?.title
+  );
+}
+
+function smsticketOccurrenceLocation(event) {
+  const place = event?.place || {};
+  const venue = event?.venue || {};
+  const location = event?.location || {};
+
+  const placeId = String(
+    place?.id || ''
+  ).trim();
+
+  const venueName =
+    venue?.name ||
+    place?.company ||
+    event?.venueName ||
+    '';
+
+  const city =
+    venue?.city ||
+    location?.city ||
+    place?.city ||
+    '';
+
+  const street =
+    venue?.address?.street ||
+    place?.street ||
+    event?.address ||
+    '';
+
+  const latitude =
+    location?.lat ??
+    location?.latitude ??
+    venue?.location?.lat ??
+    venue?.location?.latitude ??
+    '';
+
+  const longitude =
+    location?.lon ??
+    location?.longitude ??
+    venue?.location?.lon ??
+    venue?.location?.longitude ??
+    '';
+
+  const hasLocation =
+    placeId ||
+    venueName ||
+    city ||
+    street ||
+    latitude !== '' ||
+    longitude !== '';
+
+  if (!hasLocation) return '';
+
+  return [
+    placeId ? 'place-' + placeId : '',
+    venueName,
+    city,
+    street,
+    latitude !== '' ? String(latitude) : '',
+    longitude !== '' ? String(longitude) : '',
+  ]
+    .map(normalizeSmsticketOccurrencePart)
+    .filter(Boolean)
+    .join('|');
+}
+
+function smsticketExactOccurrenceKey(event) {
+  const title = smsticketOccurrenceTitle(event);
+
+  const datetime = String(
+    event?.datetime ||
+    event?.date ||
+    ''
+  ).trim();
+
+  const location =
+    smsticketOccurrenceLocation(event);
+
+  if (!title || !datetime || !location) {
+    return '';
+  }
+
+  return [
+    title,
+    datetime,
+    location,
+  ].join('||');
+}
+
+function smsticketTicketCurrency(event) {
+  const price = String(
+    event?.priceFrom || ''
+  ).trim();
+
+  if (price.includes('\u004b\u010d') || /CZK/i.test(price)) {
+    return 'CZK';
+  }
+
+  if (price.includes('\u20ac') || /EUR/i.test(price)) {
+    return 'EUR';
+  }
+
+  if (price.includes('\u00a3') || /GBP/i.test(price)) {
+    return 'GBP';
+  }
+
+  if (price.includes('$') || /USD/i.test(price)) {
+    return 'USD';
+  }
+
+  return '';
+}
+function smsticketTicketOption(event) {
+  const url = String(
+    event?.tickets ||
+    event?.url ||
+    ''
+  ).trim();
+
+  if (!url) return null;
+
+  return {
+    url,
+    priceFrom: String(
+      event?.priceFrom || ''
+    ).trim(),
+    currency:
+      smsticketTicketCurrency(event),
+    provider: 'smsticket',
+  };
+}
+
+function smsticketBookingEndMs(event) {
+  const parsed = new Date(
+    event?.bookingEndsAt || ''
+  );
+
+  return Number.isFinite(parsed.getTime())
+    ? parsed.getTime()
+    : Number.NEGATIVE_INFINITY;
+}
+
+function smsticketCurrencyRank(event) {
+  const currency =
+    smsticketTicketCurrency(event);
+
+  if (currency === 'CZK') return 0;
+  if (currency === 'EUR') return 1;
+  if (currency === 'GBP') return 2;
+  if (currency === 'USD') return 3;
+
+  return 4;
+}
+
+function compareSmsticketPrimaryEvents(
+  left,
+  right
+) {
+  const currencyDifference =
+    smsticketCurrencyRank(left) -
+    smsticketCurrencyRank(right);
+
+  if (currencyDifference !== 0) {
+    return currencyDifference;
+  }
+
+  const bookingDifference =
+    smsticketBookingEndMs(right) -
+    smsticketBookingEndMs(left);
+
+  if (bookingDifference !== 0) {
+    return bookingDifference;
+  }
+
+  const leftId = Number(
+    left?.sourceId ||
+    String(left?.id || '').replace(/\D+/g, '')
+  );
+
+  const rightId = Number(
+    right?.sourceId ||
+    String(right?.id || '').replace(/\D+/g, '')
+  );
+
+  if (
+    Number.isFinite(leftId) &&
+    Number.isFinite(rightId)
+  ) {
+    return rightId - leftId;
+  }
+
+  return String(left?.id || '').localeCompare(
+    String(right?.id || '')
+  );
+}
+
+export function mergeExactSmsticketOccurrences(
+  events = []
+) {
+  if (!Array.isArray(events) || events.length < 2) {
+    return Array.isArray(events)
+      ? [...events]
+      : [];
+  }
+
+  const groups = new Map();
+  const orderedGroups = [];
+
+  for (const event of events) {
+    const key =
+      smsticketExactOccurrenceKey(event);
+
+    if (!key) {
+      orderedGroups.push({
+        key: '',
+        events: [event],
+      });
+
+      continue;
+    }
+
+    let group = groups.get(key);
+
+    if (!group) {
+      group = {
+        key,
+        events: [],
+      };
+
+      groups.set(key, group);
+      orderedGroups.push(group);
+    }
+
+    group.events.push(event);
+  }
+
+  return orderedGroups.map((group) => {
+    if (group.events.length === 1) {
+      return group.events[0];
+    }
+
+    const sortedEvents = [
+      ...group.events,
+    ].sort(compareSmsticketPrimaryEvents);
+
+    const primary = sortedEvents[0];
+    const ticketOptions = [];
+    const seenUrls = new Set();
+
+    for (const event of sortedEvents) {
+      const option =
+        smsticketTicketOption(event);
+
+      if (!option || seenUrls.has(option.url)) {
+        continue;
+      }
+
+      seenUrls.add(option.url);
+      ticketOptions.push(option);
+    }
+
+    if (ticketOptions.length < 2) {
+      return primary;
+    }
+
+    return {
+      ...primary,
+      ticketOptions,
+    };
+  });
+}
+
 function sortEvents(events, sort = 'nearest') {
   return [...events].sort((a, b) => {
     const da = getDateMs(a?.datetime || a?.date);
@@ -557,7 +866,13 @@ export async function fetchEvents({ filters = {} } = {}) {
     );
   }
 
-  const filtered = sortEvents(candidates, filters.sort || 'nearest');
+  const deduplicated =
+    mergeExactSmsticketOccurrences(candidates);
+
+  const filtered = sortEvents(
+    deduplicated,
+    filters.sort || 'nearest'
+  );
 
   return pageSlice(filtered, filters);
 }

--- a/src/event-modal.js
+++ b/src/event-modal.js
@@ -571,6 +571,362 @@ function ensureModalStyles() {
   `);
 }
 
+// AJSEE_EVENT_MODAL_TICKET_OPTIONS_v1
+function normalizeModalTicketOptions(eventData) {
+  const rawOptions = Array.isArray(eventData?.ticketOptions)
+    ? eventData.ticketOptions
+    : [];
+
+  const seenUrls = new Set();
+  const options = [];
+
+  for (const rawOption of rawOptions) {
+    const url = String(rawOption?.url || '').trim();
+
+    if (!url || seenUrls.has(url)) continue;
+
+    seenUrls.add(url);
+
+    options.push({
+      url,
+      priceFrom: String(rawOption?.priceFrom || '').trim(),
+      currency: String(rawOption?.currency || '').trim(),
+      provider: String(rawOption?.provider || eventData?.partner || '').trim(),
+    });
+  }
+
+  return options;
+}
+
+function modalTicketOptionLabel(
+  options,
+  option,
+  index,
+  lang
+) {
+  const base = i18n(lang, 'tickets');
+  const price = String(option?.priceFrom || '').trim();
+
+  const samePriceCount = price
+    ? options.filter(
+        (candidate) => String(candidate?.priceFrom || '').trim() === price
+      ).length
+    : options.length;
+
+  const numberedBase = samePriceCount > 1
+    ? base + ' ' + String(index + 1)
+    : base;
+
+  return price
+    ? numberedBase + ' \u00b7 ' + price
+    : numberedBase;
+}
+
+
+// AJSEE_EVENT_MODAL_PARTNER_TRACKING_v1
+function modalTrackingText(value) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function modalTrackingHost(value) {
+  try {
+    return new URL(
+      value,
+      window.location.origin
+    ).hostname;
+  } catch {
+    return '';
+  }
+}
+
+function trackModalPartnerClickFromLink(link) {
+  if (!link) return;
+
+  const partner =
+    modalTrackingText(link.dataset.partner);
+
+  const eventName =
+    modalTrackingText(
+      link.dataset.eventTitle
+    );
+
+  const city =
+    modalTrackingText(
+      link.dataset.eventCity
+    );
+
+  const clickedHref =
+    modalTrackingText(
+      link.href ||
+      link.getAttribute('href')
+    );
+
+  const outboundUrl =
+    modalTrackingText(
+      link.dataset.outboundUrl
+    ) || clickedHref;
+
+  const placement =
+    modalTrackingText(
+      link.dataset.placement
+    ) || 'event_modal';
+
+  if (!partner && !outboundUrl) return;
+
+  let routeCity = '';
+  let routeCountryCode = '';
+
+  try {
+    const params =
+      new URLSearchParams(
+        window.location.search
+      );
+
+    routeCity =
+      modalTrackingText(
+        params.get('city')
+      );
+
+    routeCountryCode =
+      modalTrackingText(
+        params.get('cityCc') ||
+        params.get('country') ||
+        params.get('countryCode')
+      ).toUpperCase();
+  } catch {
+    /* noop */
+  }
+
+  const language =
+    modalTrackingText(
+      document.documentElement
+        .getAttribute('lang')
+    )
+      .slice(0, 2)
+      .toLowerCase() || 'cs';
+
+  const payload = {
+    event: 'partner_click',
+
+    // Existing analytics contract.
+    partner,
+    event_name: eventName,
+    city,
+    outbound_url: outboundUrl,
+    placement,
+    page_path:
+      window.location.pathname +
+      window.location.search,
+    ts: new Date().toISOString(),
+
+    // Extended context.
+    event_title: eventName,
+    event_city: city || routeCity,
+    event_provider: partner,
+    destination_url: outboundUrl,
+    destination_host:
+      modalTrackingHost(outboundUrl),
+    clicked_href: clickedHref,
+    clicked_host:
+      modalTrackingHost(clickedHref),
+    route_city: routeCity,
+    route_country_code:
+      routeCountryCode,
+    page_location:
+      window.location.href,
+    language,
+    link_text:
+      modalTrackingText(
+        link.textContent
+      ),
+
+    ticket_price_from:
+      modalTrackingText(
+        link.dataset.ticketPriceFrom
+      ),
+
+    ticket_currency:
+      modalTrackingText(
+        link.dataset.ticketCurrency
+      ),
+
+    ticket_option_index:
+      modalTrackingText(
+        link.dataset.ticketOptionIndex
+      ),
+  };
+
+  try {
+    window.dataLayer =
+      window.dataLayer || [];
+
+    window.dataLayer.push(payload);
+  } catch {
+    /* noop */
+  }
+
+  try {
+    window.__ajsee =
+      window.__ajsee || {};
+
+    window.__ajsee.lastPartnerClick =
+      payload;
+  } catch {
+    /* noop */
+  }
+
+  try {
+    sessionStorage.setItem(
+      'ajsee:lastPartnerClick',
+      JSON.stringify(payload)
+    );
+  } catch {
+    /* noop */
+  }
+
+  try {
+    console.info(
+      '[AJSEE partner_click]',
+      payload
+    );
+  } catch {
+    /* noop */
+  }
+}
+
+function bindModalPartnerClickTracking(link) {
+  if (!link) return;
+
+  if (
+    link.dataset
+      .ajseeModalTrackingBound === '1'
+  ) {
+    return;
+  }
+
+  link.dataset.ajseeModalTrackingBound =
+    '1';
+
+  link.addEventListener('click', () => {
+    trackModalPartnerClickFromLink(link);
+  });
+}
+
+function renderModalTicketOptions(
+  container,
+  eventData,
+  options,
+  lang,
+  title,
+  opts
+) {
+  if (!container) return 0;
+
+  container.replaceChildren();
+  container.hidden = true;
+  container.setAttribute('role', 'group');
+  container.setAttribute('aria-label', i18n(lang, 'tickets'));
+
+  const eventCity =
+    eventData?.location?.city ||
+    eventData?.venue?.city ||
+    eventData?.place?.city ||
+    '';
+
+  let renderedCount = 0;
+
+  options.forEach((option, index) => {
+    const optionEventData = {
+      ...eventData,
+      tickets: option.url,
+      url: option.url,
+      __ajseeTicketsHref: '',
+    };
+
+    const href = toSafeUrl(
+      buildModalTicketHref(
+        option.url,
+        optionEventData,
+        opts
+      )
+    );
+
+    if (!href) return;
+
+    const link = document.createElement('a');
+    link.className = 'modal-ticket-cta modal-ticket-option js-partner-click';
+    link.href = href;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+
+    const label = modalTicketOptionLabel(
+      options,
+      option,
+      index,
+      lang
+    );
+
+    link.textContent = label;
+    link.setAttribute(
+      'aria-label',
+      label + ': ' + title
+    );
+
+    link.dataset.partner =
+      option.provider || eventData?.partner || '';
+
+    link.dataset.eventTitle = title;
+    link.dataset.eventCity = eventCity;
+    link.dataset.outboundUrl = href;
+    link.dataset.placement = 'event_modal';
+
+    link.dataset.ticketPriceFrom =
+      String(option?.priceFrom || '').trim();
+
+    link.dataset.ticketCurrency =
+      String(option?.currency || '').trim();
+
+    link.dataset.ticketOptionIndex =
+      String(index + 1);
+
+    bindModalPartnerClickTracking(link);
+
+    container.appendChild(link);
+    renderedCount += 1;
+  });
+
+  container.hidden = renderedCount === 0;
+
+  return renderedCount;
+}
+
+function ensureTicketOptionsStyles() {
+  injectOnce('ajsee-event-ticket-options-css', `
+    .modal-ticket-options {
+      display: grid;
+      gap: 10px;
+      width: 100%;
+      margin: 16px 0 0;
+    }
+
+    .modal-ticket-options[hidden] {
+      display: none !important;
+    }
+
+    .modal-ticket-options .modal-ticket-cta {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      box-sizing: border-box;
+      margin: 0;
+      text-align: center;
+    }
+  `);
+}
+
 function ensureEventModalShell() {
   ensureModalStyles();
 
@@ -612,6 +968,12 @@ function ensureEventModalShell() {
             <span id="modalCategory"></span>
           </p>
 
+          <div
+            id="modalTicketOptions"
+            class="modal-ticket-options"
+            hidden
+          ></div>
+
           <a id="modalTicketsLink" class="modal-ticket-cta" href="#" target="_blank" rel="noopener noreferrer">
             Vstupenky
           </a>
@@ -641,6 +1003,8 @@ function ensureEventModalShell() {
   }
 
   ensureTicketCta(modal);
+  ensureTicketOptionsContainer(modal);
+  ensureTicketOptionsStyles();
 
   return modal;
 }
@@ -670,6 +1034,29 @@ function ensureTicketCta(modal) {
   return ticket;
 }
 
+function ensureTicketOptionsContainer(modal) {
+  if (!modal) return null;
+
+  let container = modal.querySelector('#modalTicketOptions');
+
+  if (container) return container;
+
+  container = document.createElement('div');
+  container.id = 'modalTicketOptions';
+  container.className = 'modal-ticket-options';
+  container.hidden = true;
+
+  const ticket = modal.querySelector('#modalTicketsLink');
+  const details = modal.querySelector('.modal-details');
+
+  if (ticket?.parentNode) {
+    ticket.parentNode.insertBefore(container, ticket);
+  } else if (details) {
+    details.appendChild(container);
+  }
+
+  return container;
+}
 function setStaticModalLabels(modal, lang) {
   const closeBtn = modal.querySelector('#modalClose');
   if (closeBtn) {
@@ -806,6 +1193,9 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
   // Preferujeme ticket link spočítaný při renderu karty,
   // ale pro modal přepíšeme tmOutbound placement na event_modal.
   // Tím neobcházíme affiliate flow a zároveň v Impactu oddělíme kliky z modalu.
+  const ticketOptions =
+    normalizeModalTicketOptions(eventData);
+
   const rawTicketHref =
     eventData.__ajseeTicketsHref ||
     eventData.tickets ||
@@ -823,6 +1213,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
   const descEl = modal.querySelector('#modalDescription');
   const categoryEl = modal.querySelector('#modalCategory');
   const ticketEl = modal.querySelector('#modalTicketsLink');
+  const ticketOptionsEl = modal.querySelector('#modalTicketOptions');
 
   if (titleEl) titleEl.textContent = title;
 
@@ -836,16 +1227,72 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
   if (descEl) descEl.textContent = description;
   if (categoryEl) categoryEl.textContent = translateCategory(eventData.category, lang);
 
+  const renderedTicketOptions =
+    ticketOptions.length > 1
+      ? renderModalTicketOptions(
+          ticketOptionsEl,
+          eventData,
+          ticketOptions,
+          lang,
+          title,
+          opts
+        )
+      : 0;
+
+  if (ticketOptionsEl && renderedTicketOptions === 0) {
+    ticketOptionsEl.replaceChildren();
+    ticketOptionsEl.hidden = true;
+  }
+
   if (ticketEl) {
     ticketEl.textContent = i18n(lang, 'tickets');
 
-    if (ticketHref) {
+    ticketEl.dataset.partner = String(
+      eventData?.partner ||
+      eventData?.source ||
+      ''
+    ).trim();
+
+    ticketEl.dataset.eventTitle = title;
+
+    ticketEl.dataset.eventCity = String(
+      locationObj?.city ||
+      eventData?.venue?.city ||
+      eventData?.place?.city ||
+      ''
+    ).trim();
+
+    ticketEl.dataset.outboundUrl =
+      ticketHref || '';
+
+    ticketEl.dataset.placement = 'event_modal';
+
+    ticketEl.dataset.ticketPriceFrom =
+      String(
+        eventData?.priceFrom ||
+        ''
+      ).trim();
+
+    ticketEl.dataset.ticketCurrency = '';
+    ticketEl.dataset.ticketOptionIndex = '1';
+
+    bindModalPartnerClickTracking(ticketEl);
+
+    if (renderedTicketOptions > 1) {
+      ticketEl.href = '#';
+      ticketEl.hidden = true;
+      ticketEl.removeAttribute('aria-label');
+    } else if (ticketHref) {
       ticketEl.href = ticketHref;
       ticketEl.hidden = false;
-      ticketEl.setAttribute('aria-label', `${i18n(lang, 'tickets')}: ${title}`);
+      ticketEl.setAttribute(
+        'aria-label',
+        i18n(lang, 'tickets') + ': ' + title
+      );
     } else {
       ticketEl.href = '#';
       ticketEl.hidden = true;
+      ticketEl.removeAttribute('aria-label');
     }
   }
 

--- a/tests/smsticket-ticket-options.test.mjs
+++ b/tests/smsticket-ticket-options.test.mjs
@@ -1,0 +1,353 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+import {
+  mergeExactSmsticketOccurrences,
+} from '../src/adapters/smsticket.js';
+
+function occurrence(overrides = {}) {
+  return {
+    id: 'smsticket-1',
+    sourceId: '1',
+    partner: 'smsticket',
+    source: 'smsticket',
+    title: {
+      cs: 'Testovaci akce',
+      en: 'Test event',
+    },
+    datetime: '2026-10-20T08:30:00',
+    date: '2026-10-20',
+    bookingEndsAt: '2026-10-20T07:30:00',
+    priceFrom: '500 CZK',
+    tickets:
+      'https://www.smsticket.cz/vstupenky/1-test',
+    url:
+      'https://www.smsticket.cz/vstupenky/1-test',
+    location: {
+      city: 'Praha',
+      country: 'CZ',
+      lat: 50.1084247,
+      lon: 14.4869633,
+    },
+    place: {
+      id: '8463',
+      company: 'UNYP ARENA',
+      city: 'Praha',
+      street: 'Kovanecka 2405/27',
+    },
+    venue: {
+      name: 'UNYP ARENA',
+      city: 'Praha',
+      address: {
+        street: 'Kovanecka 2405/27',
+      },
+    },
+    ...overrides,
+  };
+}
+
+test(
+  'merges the IDO currency variants and prefers CZK',
+  () => {
+    const eur = occurrence({
+      id: 'smsticket-71242',
+      sourceId: '71242',
+      priceFrom: '25 EUR',
+      tickets:
+        'https://www.smsticket.cz/vstupenky/71242-ido',
+      url:
+        'https://www.smsticket.cz/vstupenky/71242-ido',
+    });
+
+    const czk = occurrence({
+      id: 'smsticket-71109',
+      sourceId: '71109',
+      priceFrom: '750 CZK',
+      tickets:
+        'https://www.smsticket.cz/vstupenky/71109-ido',
+      url:
+        'https://www.smsticket.cz/vstupenky/71109-ido',
+    });
+
+    const result =
+      mergeExactSmsticketOccurrences([
+        eur,
+        czk,
+      ]);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'smsticket-71109');
+
+    assert.deepEqual(
+      result[0].ticketOptions,
+      [
+        {
+          url:
+            'https://www.smsticket.cz/vstupenky/71109-ido',
+          priceFrom: '750 CZK',
+          currency: 'CZK',
+          provider: 'smsticket',
+        },
+        {
+          url:
+            'https://www.smsticket.cz/vstupenky/71242-ido',
+          priceFrom: '25 EUR',
+          currency: 'EUR',
+          provider: 'smsticket',
+        },
+      ]
+    );
+  }
+);
+
+test(
+  'prefers the same-currency event with later booking end',
+  () => {
+    const earlier = occurrence({
+      id: 'smsticket-69262',
+      sourceId: '69262',
+      title: {
+        cs:
+          'Karel Kahovec + Beatles Revival + Michal Sindelar',
+      },
+      datetime: '2026-11-07T20:00:00',
+      bookingEndsAt: '2026-11-07T18:00:00',
+      priceFrom: '390 CZK',
+      tickets:
+        'https://www.smsticket.cz/vstupenky/69262-karel',
+      url:
+        'https://www.smsticket.cz/vstupenky/69262-karel',
+      place: {
+        id: '4179',
+        company: 'Kulturni dum Dvorana',
+        city: 'Loket',
+        street: 'Radnicni 312',
+      },
+      venue: {
+        name: 'Kulturni dum Dvorana',
+        city: 'Loket',
+        address: {
+          street: 'Radnicni 312',
+        },
+      },
+      location: {
+        city: 'Loket',
+        country: 'CZ',
+      },
+    });
+
+    const later = occurrence({
+      ...earlier,
+      id: 'smsticket-69323',
+      sourceId: '69323',
+      bookingEndsAt: '2026-11-07T19:00:00',
+      tickets:
+        'https://www.smsticket.cz/vstupenky/69323-karel',
+      url:
+        'https://www.smsticket.cz/vstupenky/69323-karel',
+    });
+
+    const result =
+      mergeExactSmsticketOccurrences([
+        earlier,
+        later,
+      ]);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, 'smsticket-69323');
+    assert.equal(result[0].ticketOptions.length, 2);
+  }
+);
+
+test(
+  'does not merge the same title and time in different cities',
+  () => {
+    const prague = occurrence();
+
+    const brno = occurrence({
+      id: 'smsticket-2',
+      sourceId: '2',
+      tickets:
+        'https://www.smsticket.cz/vstupenky/2-test',
+      url:
+        'https://www.smsticket.cz/vstupenky/2-test',
+      location: {
+        city: 'Brno',
+        country: 'CZ',
+      },
+      place: {
+        id: '9999',
+        company: 'Sono Centrum',
+        city: 'Brno',
+        street: 'Veveri 113',
+      },
+      venue: {
+        name: 'Sono Centrum',
+        city: 'Brno',
+        address: {
+          street: 'Veveri 113',
+        },
+      },
+    });
+
+    const result =
+      mergeExactSmsticketOccurrences([
+        prague,
+        brno,
+      ]);
+
+    assert.equal(result.length, 2);
+  }
+);
+
+test(
+  'does not merge different times at the same venue',
+  () => {
+    const afternoon = occurrence({
+      datetime: '2026-10-20T14:00:00',
+    });
+
+    const evening = occurrence({
+      id: 'smsticket-2',
+      sourceId: '2',
+      datetime: '2026-10-20T17:00:00',
+      tickets:
+        'https://www.smsticket.cz/vstupenky/2-test',
+      url:
+        'https://www.smsticket.cz/vstupenky/2-test',
+    });
+
+    const result =
+      mergeExactSmsticketOccurrences([
+        afternoon,
+        evening,
+      ]);
+
+    assert.equal(result.length, 2);
+  }
+);
+
+test(
+  'keeps a normal single event unchanged',
+  () => {
+    const event = occurrence();
+
+    const result =
+      mergeExactSmsticketOccurrences([event]);
+
+    assert.equal(result.length, 1);
+    assert.equal(result[0], event);
+
+    assert.equal(
+      Object.hasOwn(result[0], 'ticketOptions'),
+      false
+    );
+  }
+);
+
+test(
+  'does not duplicate the same ticket URL',
+  () => {
+    const first = occurrence();
+
+    const second = occurrence({
+      id: 'smsticket-2',
+      sourceId: '2',
+    });
+
+    const result =
+      mergeExactSmsticketOccurrences([
+        first,
+        second,
+      ]);
+
+    assert.equal(result.length, 1);
+
+    assert.equal(
+      Object.hasOwn(result[0], 'ticketOptions'),
+      false
+    );
+  }
+);
+
+test(
+  'event modal contains the multiple-ticket UI path',
+  () => {
+    const modalSource = fs.readFileSync(
+      new URL(
+        '../src/event-modal.js',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+    assert.match(
+      modalSource,
+      /normalizeModalTicketOptions/
+    );
+
+    assert.match(
+      modalSource,
+      /modalTicketOptions/
+    );
+
+    assert.match(
+      modalSource,
+      /renderModalTicketOptions/
+    );
+  }
+);
+
+test(
+  'tracks single and multiple modal ticket clicks',
+  () => {
+    const modalSource = fs.readFileSync(
+      new URL(
+        '../src/event-modal.js',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+    assert.match(
+      modalSource,
+      /trackModalPartnerClickFromLink/
+    );
+
+    assert.match(
+      modalSource,
+      /bindModalPartnerClickTracking/
+    );
+
+    assert.match(
+      modalSource,
+      /const placement\s*=/
+    );
+
+    assert.match(
+      modalSource,
+      /\r?\n\s*placement,\r?\n/
+    );
+
+    assert.match(
+      modalSource,
+      /ticket_currency/
+    );
+
+    assert.match(
+      modalSource,
+      /ticket_option_index/
+    );
+
+    assert.match(
+      modalSource,
+      /\\u00b7/
+    );
+
+    assert.doesNotMatch(
+      modalSource,
+      /numberedBase \+ ' \? ' \+ price/
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Groups exact SMS Ticket occurrences that represent multiple ticket offers for the same event.

Instead of displaying duplicate event cards, AJSEE now keeps one primary event card and exposes all unique purchase options inside the event modal.

## What changed

- groups SMS Ticket records only when normalized title, exact date/time and location match
- keeps events in different cities or at different times separate
- prefers CZK as the primary offer when currency variants exist
- otherwise prefers the offer with the later booking end
- preserves all unique ticket URLs in `ticketOptions`
- keeps the existing `tickets` and `url` fields as the primary fallback
- displays multiple ticket options in the shared event modal
- preserves the existing single-ticket modal behaviour
- tracks modal ticket clicks with `partner_click`
- uses `placement: event_modal`
- includes ticket currency, price and option index in analytics
- adds regression tests to the standard `reviews:test` command

## Production feed verification

Current production feed:

- input events: 2,662
- resulting event cards: 2,660
- grouped occurrences: 2
- events with multiple ticket options: 2

Verified groups:

1. IDO World Tap Dance Championships 2026
   - CZK offer retained as primary
   - EUR offer retained as an additional option

2. Karel Kahovec + Beatles Revival + Michal Šindelář
   - both unique SMS Ticket purchase links retained
   - later booking end selected as primary

Verified that:

- same title and time in different cities remain separate
- different times at the same venue remain separate
- duplicate ticket URLs are not repeated

## Tests

- `npm run reviews:test` — 20/20 passed
- JavaScript syntax checks passed
- `git diff --check` passed
- production build passed