### PR TITLE
test(events): cover modal ticket options behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
                 "vite-plugin-static-copy": "^3.1.1",
                 "webpack": "^5.89.0",
                 "webpack-cli": "^5.1.4",
-                "webpack-dev-server": "^5.2.2"
+                "webpack-dev-server": "^5.2.2",
+                "jsdom": "26.1.0"
             },
             "engines": {
                 "node": "20.x"
@@ -25590,6 +25591,519 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+            "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/css-calc": "^2.1.3",
+                "@csstools/css-color-parser": "^3.0.9",
+                "@csstools/css-parser-algorithms": "^3.0.4",
+                "@csstools/css-tokenizer": "^3.0.3",
+                "lru-cache": "^10.4.3"
+            }
+        },
+        "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+            "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+            "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+            "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^5.1.0",
+                "@csstools/css-calc": "^2.1.4"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^3.0.5",
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+            "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^3.0.4"
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+            "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/cssstyle": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+            "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^3.2.0",
+                "rrweb-cssom": "^0.8.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls/node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "26.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+            "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssstyle": "^4.2.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.5.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.16",
+                "parse5": "^7.2.1",
+                "rrweb-cssom": "^0.8.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^5.1.1",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.1.1",
+                "ws": "^8.18.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/tr46": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+            "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-url": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+            "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tr46": "^5.1.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/nwsapi": {
+            "version": "2.2.24",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+            "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/rrweb-cssom": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+            "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tldts": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+            "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^6.1.86"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "6.1.86",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+            "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tough-cookie": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+            "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^6.1.32"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "reviews:build": "node scripts/build-reviews.mjs",
     "review-details:build": "node scripts/build-review-details.mjs",
     "review-details:localize": "cross-env REVIEW_LOCALIZE=1 node scripts/build-review-details.mjs",
-    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs"
+    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs tests/event-modal-ticket-options-dom.test.mjs",
+    "events:modal:test": "node --test --test-concurrency=1 tests/event-modal-ticket-options-dom.test.mjs"
   },
   "devDependencies": {
     "@squoosh/cli": "^0.7.1",
@@ -41,6 +42,7 @@
     "css-loader": "^6.9.1",
     "cwebp-bin": "^8.0.0",
     "fast-xml-parser": "^5.8.0",
+    "jsdom": "26.1.0",
     "mini-css-extract-plugin": "^2.7.6",
     "netlify-cli": "^23.9.1",
     "sass-embedded": "^1.90.0",

--- a/tests/event-modal-ticket-options-dom.test.mjs
+++ b/tests/event-modal-ticket-options-dom.test.mjs
@@ -1,0 +1,954 @@
+﻿import test, {
+  after,
+  afterEach,
+  beforeEach,
+} from 'node:test';
+
+import assert from 'node:assert/strict';
+
+import {
+  JSDOM,
+} from 'jsdom';
+
+const dom = new JSDOM(
+  `<!doctype html>
+  <html lang="cs">
+    <head>
+      <title>AJSEE modal test</title>
+    </head>
+    <body data-page="events">
+      <button id="previous-focus" type="button">
+        Previous focus
+      </button>
+    </body>
+  </html>`,
+  {
+    url:
+      'https://ajsee.cz/events?city=Loket&cityCc=CZ',
+    pretendToBeVisual: true,
+  }
+);
+
+const globalValues = {
+  window:
+    dom.window,
+
+  document:
+    dom.window.document,
+
+  MutationObserver:
+    dom.window.MutationObserver,
+
+  HTMLElement:
+    dom.window.HTMLElement,
+
+  Element:
+    dom.window.Element,
+
+  Node:
+    dom.window.Node,
+
+  Event:
+    dom.window.Event,
+
+  MouseEvent:
+    dom.window.MouseEvent,
+
+  KeyboardEvent:
+    dom.window.KeyboardEvent,
+
+  CustomEvent:
+    dom.window.CustomEvent,
+
+  sessionStorage:
+    dom.window.sessionStorage,
+
+  getComputedStyle:
+    dom.window.getComputedStyle.bind(
+      dom.window
+    ),
+};
+
+const previousGlobalDescriptors =
+  new Map();
+
+for (
+  const [
+    name,
+    value,
+  ] of Object.entries(globalValues)
+) {
+  previousGlobalDescriptors.set(
+    name,
+    Object.getOwnPropertyDescriptor(
+      globalThis,
+      name
+    )
+  );
+
+  Object.defineProperty(
+    globalThis,
+    name,
+    {
+      configurable: true,
+      writable: true,
+      value,
+    }
+  );
+}
+
+const moduleUrl =
+  new URL(
+    '../src/event-modal.js',
+    import.meta.url
+  );
+
+moduleUrl.searchParams.set(
+  'dom-test',
+  String(Date.now())
+);
+
+const {
+  openEventModal,
+} =
+  await import(moduleUrl.href);
+
+function createEvent(
+  overrides = {}
+) {
+  return {
+    id:
+      'smsticket-1',
+
+    partner:
+      'smsticket',
+
+    source:
+      'smsticket',
+
+    title: {
+      cs:
+        'Testovací akce',
+
+      en:
+        'Test event',
+    },
+
+    description: {
+      cs:
+        'Testovací popis události.',
+
+      en:
+        'Test event description.',
+    },
+
+    category:
+      'concert',
+
+    priceFrom:
+      '390 CZK',
+
+    tickets:
+      'https://www.smsticket.cz/vstupenky/1-test',
+
+    url:
+      'https://www.smsticket.cz/vstupenky/1-test',
+
+    location: {
+      city:
+        'Loket',
+
+      country:
+        'CZ',
+    },
+
+    venue: {
+      name:
+        'Kulturní dům Dvorana',
+
+      city:
+        'Loket',
+    },
+
+    ...overrides,
+  };
+}
+
+function getModal() {
+  const modal =
+    document.getElementById(
+      'eventModal'
+    );
+
+  assert.ok(
+    modal,
+    'Event modal must exist.'
+  );
+
+  return modal;
+}
+
+function getTicketOptions(
+  modal = getModal()
+) {
+  const container =
+    modal.querySelector(
+      '#modalTicketOptions'
+    );
+
+  assert.ok(
+    container,
+    'Ticket options container must exist.'
+  );
+
+  return container;
+}
+
+function getPrimaryTicketLink(
+  modal = getModal()
+) {
+  const link =
+    modal.querySelector(
+      '#modalTicketsLink'
+    );
+
+  assert.ok(
+    link,
+    'Primary ticket link must exist.'
+  );
+
+  return link;
+}
+
+function getRenderedOptionLinks(
+  modal = getModal()
+) {
+  return [
+    ...modal.querySelectorAll(
+      '#modalTicketOptions ' +
+      'a.modal-ticket-option'
+    ),
+  ];
+}
+
+function clickWithoutNavigation(
+  link
+) {
+  const preventNavigation =
+    (event) => {
+      if (
+        event.target
+          ?.closest?.('a') === link
+      ) {
+        event.preventDefault();
+      }
+    };
+
+  document.addEventListener(
+    'click',
+    preventNavigation,
+    true
+  );
+
+  try {
+    link.dispatchEvent(
+      new dom.window.MouseEvent(
+        'click',
+        {
+          bubbles: true,
+          cancelable: true,
+          view: dom.window,
+        }
+      )
+    );
+  } finally {
+    document.removeEventListener(
+      'click',
+      preventNavigation,
+      true
+    );
+  }
+}
+
+function resetRuntimeState() {
+  window.__ajseeCloseEventModal?.();
+
+  window.dataLayer = [];
+  window.__ajsee = {};
+
+  sessionStorage.clear();
+
+  document.body.style.overflow = '';
+
+  const previousFocus =
+    document.getElementById(
+      'previous-focus'
+    );
+
+  previousFocus?.focus();
+}
+
+beforeEach(() => {
+  resetRuntimeState();
+});
+
+afterEach(() => {
+  window.__ajseeCloseEventModal?.();
+});
+
+after(() => {
+  dom.window.close();
+
+  for (
+    const [
+      name,
+      descriptor,
+    ] of previousGlobalDescriptors
+  ) {
+    if (descriptor) {
+      Object.defineProperty(
+        globalThis,
+        name,
+        descriptor
+      );
+    } else {
+      delete globalThis[name];
+    }
+  }
+});
+
+test(
+  'renders one primary CTA for a normal event',
+  async () => {
+    await openEventModal(
+      createEvent(),
+      'cs'
+    );
+
+    const modal =
+      getModal();
+
+    const container =
+      getTicketOptions(modal);
+
+    const primaryLink =
+      getPrimaryTicketLink(modal);
+
+    assert.equal(
+      modal.classList.contains('open'),
+      true
+    );
+
+    assert.equal(
+      modal.getAttribute('aria-hidden'),
+      'false'
+    );
+
+    assert.equal(
+      container.hidden,
+      true
+    );
+
+    assert.equal(
+      getRenderedOptionLinks(modal).length,
+      0
+    );
+
+    assert.equal(
+      primaryLink.hidden,
+      false
+    );
+
+    assert.equal(
+      primaryLink.textContent.trim(),
+      'Vstupenky'
+    );
+
+    assert.equal(
+      primaryLink.getAttribute(
+        'aria-label'
+      ),
+      'Vstupenky: Testovací akce'
+    );
+
+    assert.equal(
+      primaryLink.dataset.placement,
+      'event_modal'
+    );
+
+    assert.equal(
+      primaryLink.dataset
+        .ajseeModalTrackingBound,
+      '1'
+    );
+
+    assert.match(
+      primaryLink.href,
+      /\/vstupenky\/1-test/
+    );
+  }
+);
+
+test(
+  'renders two accessible ticket options and hides the primary CTA',
+  async () => {
+    await openEventModal(
+      createEvent({
+        ticketOptions: [
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/69323-karel',
+
+            priceFrom:
+              '390 CZK',
+
+            currency:
+              'CZK',
+
+            provider:
+              'smsticket',
+          },
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/69262-karel',
+
+            priceFrom:
+              '390 CZK',
+
+            currency:
+              'CZK',
+
+            provider:
+              'smsticket',
+          },
+        ],
+      }),
+      'cs'
+    );
+
+    const modal =
+      getModal();
+
+    const container =
+      getTicketOptions(modal);
+
+    const primaryLink =
+      getPrimaryTicketLink(modal);
+
+    const links =
+      getRenderedOptionLinks(modal);
+
+    assert.equal(
+      container.hidden,
+      false
+    );
+
+    assert.equal(
+      container.getAttribute('role'),
+      'group'
+    );
+
+    assert.equal(
+      container.getAttribute(
+        'aria-label'
+      ),
+      'Vstupenky'
+    );
+
+    assert.equal(
+      primaryLink.hidden,
+      true
+    );
+
+    assert.equal(
+      links.length,
+      2
+    );
+
+    assert.deepEqual(
+      links.map(
+        (link) =>
+          link.textContent.trim()
+      ),
+      [
+        'Vstupenky 1 · 390 CZK',
+        'Vstupenky 2 · 390 CZK',
+      ]
+    );
+
+    assert.deepEqual(
+      links.map(
+        (link) =>
+          link.getAttribute(
+            'aria-label'
+          )
+      ),
+      [
+        'Vstupenky 1 · 390 CZK: Testovací akce',
+        'Vstupenky 2 · 390 CZK: Testovací akce',
+      ]
+    );
+
+    assert.deepEqual(
+      links.map(
+        (link) =>
+          link.dataset
+            .ticketOptionIndex
+      ),
+      [
+        '1',
+        '2',
+      ]
+    );
+
+    assert.ok(
+      links.every(
+        (link) =>
+          link.target === '_blank'
+      )
+    );
+
+    assert.ok(
+      links.every(
+        (link) =>
+          link.rel ===
+          'noopener noreferrer'
+      )
+    );
+  }
+);
+
+test(
+  'removes duplicate ticket URLs before rendering',
+  async () => {
+    await openEventModal(
+      createEvent({
+        ticketOptions: [
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/1-test',
+
+            priceFrom:
+              '390 CZK',
+
+            currency:
+              'CZK',
+          },
+          {
+            url:
+              '  https://www.smsticket.cz/vstupenky/1-test  ',
+
+            priceFrom:
+              '390 CZK',
+
+            currency:
+              'CZK',
+          },
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/2-test',
+
+            priceFrom:
+              '25 EUR',
+
+            currency:
+              'EUR',
+          },
+        ],
+      }),
+      'cs'
+    );
+
+    const links =
+      getRenderedOptionLinks();
+
+    assert.equal(
+      links.length,
+      2
+    );
+
+    assert.equal(
+      new Set(
+        links.map(
+          (link) => link.href
+        )
+      ).size,
+      2
+    );
+
+    assert.deepEqual(
+      links.map(
+        (link) =>
+          link.textContent.trim()
+      ),
+      [
+        'Vstupenky · 390 CZK',
+        'Vstupenky · 25 EUR',
+      ]
+    );
+  }
+);
+
+test(
+  'clears old options when the modal is reopened for a single-ticket event',
+  async () => {
+    await openEventModal(
+      createEvent({
+        ticketOptions: [
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/1-test',
+
+            priceFrom:
+              '390 CZK',
+
+            currency:
+              'CZK',
+          },
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/2-test',
+
+            priceFrom:
+              '25 EUR',
+
+            currency:
+              'EUR',
+          },
+        ],
+      }),
+      'cs'
+    );
+
+    assert.equal(
+      getRenderedOptionLinks().length,
+      2
+    );
+
+    await openEventModal(
+      createEvent({
+        id:
+          'smsticket-3',
+
+        title: {
+          cs:
+            'Jiná testovací akce',
+        },
+
+        tickets:
+          'https://www.smsticket.cz/vstupenky/3-test',
+
+        url:
+          'https://www.smsticket.cz/vstupenky/3-test',
+      }),
+      'cs'
+    );
+
+    const container =
+      getTicketOptions();
+
+    const primaryLink =
+      getPrimaryTicketLink();
+
+    assert.equal(
+      container.hidden,
+      true
+    );
+
+    assert.equal(
+      container.children.length,
+      0
+    );
+
+    assert.equal(
+      primaryLink.hidden,
+      false
+    );
+
+    assert.match(
+      primaryLink.href,
+      /\/vstupenky\/3-test/
+    );
+
+    assert.equal(
+      primaryLink.getAttribute(
+        'aria-label'
+      ),
+      'Vstupenky: Jiná testovací akce'
+    );
+  }
+);
+
+test(
+  'tracks one event per click after repeated modal openings',
+  async () => {
+    const eventData =
+      createEvent();
+
+    await openEventModal(
+      eventData,
+      'cs'
+    );
+
+    let primaryLink =
+      getPrimaryTicketLink();
+
+    clickWithoutNavigation(
+      primaryLink
+    );
+
+    assert.equal(
+      window.dataLayer.length,
+      1
+    );
+
+    await openEventModal(
+      eventData,
+      'cs'
+    );
+
+    primaryLink =
+      getPrimaryTicketLink();
+
+    clickWithoutNavigation(
+      primaryLink
+    );
+
+    assert.equal(
+      window.dataLayer.length,
+      2,
+      'Repeated opening must not duplicate click listeners.'
+    );
+
+    const payload =
+      window.dataLayer.at(-1);
+
+    assert.equal(
+      payload.event,
+      'partner_click'
+    );
+
+    assert.equal(
+      payload.partner,
+      'smsticket'
+    );
+
+    assert.equal(
+      payload.placement,
+      'event_modal'
+    );
+
+    assert.equal(
+      payload.ticket_option_index,
+      '1'
+    );
+
+    assert.equal(
+      payload.ticket_price_from,
+      '390 CZK'
+    );
+
+    assert.equal(
+      payload.page_path,
+      '/events?city=Loket&cityCc=CZ'
+    );
+
+    assert.equal(
+      payload.route_city,
+      'Loket'
+    );
+
+    assert.equal(
+      payload.route_country_code,
+      'CZ'
+    );
+
+    const storedPayload =
+      JSON.parse(
+        sessionStorage.getItem(
+          'ajsee:lastPartnerClick'
+        )
+      );
+
+    assert.equal(
+      storedPayload.event,
+      'partner_click'
+    );
+
+    assert.equal(
+      storedPayload.placement,
+      'event_modal'
+    );
+  }
+);
+
+test(
+  'tracks the selected multiple-ticket option with its price and currency',
+  async () => {
+    await openEventModal(
+      createEvent({
+        ticketOptions: [
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/71109-ido',
+
+            priceFrom:
+              '750 CZK',
+
+            currency:
+              'CZK',
+
+            provider:
+              'smsticket',
+          },
+          {
+            url:
+              'https://www.smsticket.cz/vstupenky/71242-ido',
+
+            priceFrom:
+              '25 EUR',
+
+            currency:
+              'EUR',
+
+            provider:
+              'smsticket',
+          },
+        ],
+      }),
+      'cs'
+    );
+
+    const links =
+      getRenderedOptionLinks();
+
+    assert.equal(
+      links.length,
+      2
+    );
+
+    clickWithoutNavigation(
+      links[1]
+    );
+
+    assert.equal(
+      window.dataLayer.length,
+      1
+    );
+
+    const payload =
+      window.dataLayer[0];
+
+    assert.equal(
+      payload.event,
+      'partner_click'
+    );
+
+    assert.equal(
+      payload.placement,
+      'event_modal'
+    );
+
+    assert.equal(
+      payload.ticket_option_index,
+      '2'
+    );
+
+    assert.equal(
+      payload.ticket_price_from,
+      '25 EUR'
+    );
+
+    assert.equal(
+      payload.ticket_currency,
+      'EUR'
+    );
+
+    assert.equal(
+      payload.destination_host,
+      'www.smsticket.cz'
+    );
+
+    assert.match(
+      payload.outbound_url,
+      /71242-ido/
+    );
+
+    assert.equal(
+      payload.link_text,
+      'Vstupenky · 25 EUR'
+    );
+
+    assert.equal(
+      window.__ajsee
+        .lastPartnerClick,
+      payload
+    );
+  }
+);
+
+test(
+  'rejects unsafe option URLs and keeps the safe primary CTA',
+  async () => {
+    await openEventModal(
+      createEvent({
+        ticketOptions: [
+          {
+            url:
+              'javascript:alert(1)',
+
+            priceFrom:
+              '390 CZK',
+
+            currency:
+              'CZK',
+          },
+          {
+            url:
+              'data:text/html,unsafe',
+
+            priceFrom:
+              '25 EUR',
+
+            currency:
+              'EUR',
+          },
+        ],
+      }),
+      'cs'
+    );
+
+    const container =
+      getTicketOptions();
+
+    const primaryLink =
+      getPrimaryTicketLink();
+
+    assert.equal(
+      container.hidden,
+      true
+    );
+
+    assert.equal(
+      getRenderedOptionLinks().length,
+      0
+    );
+
+    assert.equal(
+      primaryLink.hidden,
+      false
+    );
+
+    assert.match(
+      primaryLink.href,
+      /\/vstupenky\/1-test/
+    );
+
+    assert.equal(
+      primaryLink.getAttribute(
+        'aria-label'
+      ),
+      'Vstupenky: Testovací akce'
+    );
+  }
+);


### PR DESCRIPTION
## Summary

- add `jsdom` 26.1.0 as a test-only dependency
- add real DOM behavior tests for the event modal ticket options
- cover single and multiple ticket CTAs, URL deduplication, modal reopening, analytics tracking, accessibility attributes, and unsafe URLs
- include the new DOM test in the existing serial test suite

## Validation

- `npm run events:modal:test` — 7/7 passed
- `npm run reviews:test` — 27/27 passed
- `npm run build` — passed

## Scope

This PR changes test infrastructure only. No production source code or generated production output is included.