### PR TITLE
feat(events): improve filter discovery UX

### DIFF
--- a/events.html
+++ b/events.html
@@ -267,11 +267,13 @@
         <form id="events-filters-form" class="events-filters filter-dock" novalidate role="search">
           <div class="filters-toolbar" aria-label="Rychlé filtry">
             <div class="chips">
-              <button type="button" class="chip" id="chipToday" data-i18n-key="filters.today">Dnes</button>
-              <button type="button" class="chip" id="chipWeekend" data-i18n-key="filters.weekend">Tento víkend</button>
+              <button type="button" class="chip" id="chipToday" data-i18n-key="filters.today" aria-pressed="false">Dnes</button>
+              <button type="button" class="chip" id="chipTomorrow" data-i18n-key="filters.tomorrow" aria-pressed="false">Zítra</button>
+              <button type="button" class="chip" id="chipThisWeek" data-i18n-key="filters.thisWeek" aria-pressed="false">Tento týden</button>
+              <button type="button" class="chip" id="chipWeekend" data-i18n-key="filters.weekend" aria-pressed="false">Tento víkend</button>
               <button type="button" class="chip ghost" id="chipClear" data-i18n-key="filters.reset">Vymazat</button>
             </div>
-            <button type="button" class="chip chip-near" id="chipNearMe" aria-label="V mém okolí" data-i18n-aria="filters.nearMe" title="V mém okolí">
+            <button type="button" class="chip chip-near" id="chipNearMe" aria-pressed="false" aria-label="V mém okolí" data-i18n-aria="filters.nearMe" title="V mém okolí">
               <svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"></circle><path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9l2.1 2.1M17 17l2.1 2.1M4.9 19.1l2.1-2.1M17 7l2.1-2.1"/></svg>
               <span data-i18n-key="filters.nearMe">V mém okolí</span>
             </button>

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "reviews:build": "node scripts/build-reviews.mjs",
     "review-details:build": "node scripts/build-review-details.mjs",
     "review-details:localize": "cross-env REVIEW_LOCALIZE=1 node scripts/build-review-details.mjs",
-    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs tests/event-modal-ticket-options-dom.test.mjs",
-    "events:modal:test": "node --test --test-concurrency=1 tests/event-modal-ticket-options-dom.test.mjs"
+    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs tests/event-modal-ticket-options-dom.test.mjs tests/events-filter-ux.test.mjs",
+    "events:modal:test": "node --test --test-concurrency=1 tests/event-modal-ticket-options-dom.test.mjs",
+    "events:filters:test": "node --test --test-concurrency=1 tests/events-filter-ux.test.mjs"
   },
   "devDependencies": {
     "@squoosh/cli": "^0.7.1",

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -16,6 +16,12 @@
 
 import './identity-init.js';
 import './utils/ajsee-date-popover.js';
+import {
+  detectDatePreset,
+  getActiveFilterDescriptors,
+  getDatePresetRange,
+  renderEventsFilterSummary
+} from './events-filter-ux.js';
 
 import { initLangDropdown } from './utils/lang-dropdown.js';
 import { initCookieBanner, syncCookieBannerLanguage } from './utils/cookie-banner.js';
@@ -722,7 +728,12 @@ function forceInlineFilters(doc = document) {
     .forEach(sel => doc.querySelectorAll(sel).forEach(el => el.remove()));
 
   const toolbar = doc.querySelector('.filters-toolbar');
-  if (toolbar) toolbar.remove();
+
+  /* AJSEE_PRESERVE_EVENTS_QUICK_FILTERS_V1 */
+  const preserveEventsToolbar =
+    doc.body?.dataset?.page === 'events';
+
+  if (toolbar && !preserveEventsToolbar) toolbar.remove();
 
   form.hidden = false;
   form.classList.remove('is-hidden', 'is-collapsed', 'is-open');
@@ -1231,8 +1242,13 @@ function renderEventsStateMessage(kind = 'rateLimit') {
     ? getRateLimitCopy()
     : {
         title: t('events-empty-title', currentLang === 'en' ? 'No events found' : 'Nenašli jsme žádné akce'),
-        body: t('events-empty-body', currentLang === 'en' ? 'Try changing the city, date or category.' : 'Zkuste upravit město, datum nebo kategorii.'),
-        retry: t('filters.apply', currentLang === 'en' ? 'Apply filters' : 'Použít filtry')
+        body: t(
+          'events-empty-body',
+          currentLang === 'en'
+            ? 'Remove one of the active filters or clear them all.'
+            : 'Odeberte některý z aktivních filtrů nebo je všechny vymažte.'
+        ),
+        retry: t('events-empty-clear', currentLang === 'en' ? 'Clear filters' : 'Vymazat filtry')
       };
 
   updateResultsCount(kind === 'rateLimit' ? 'dočasně pozastaveno' : 0);
@@ -1251,6 +1267,11 @@ function renderEventsStateMessage(kind = 'rateLimit') {
     retry.addEventListener('click', () => {
       if (kind === 'rateLimit' && isTicketmasterRateLimited()) {
         renderEventsStateMessage(kind);
+        return;
+      }
+
+      if (kind === 'empty') {
+        void resetAllEventFilters();
         return;
       }
 
@@ -1624,15 +1645,39 @@ function expandFilters() {
   announce(ariaToggleText('expanded'));
 }
 
+/* AJSEE_EVENTS_FILTER_UX_V1 */
+function getEventsFilterUxLabels() {
+  return {
+    found: t('events-found', currentLang === 'en' ? 'Found' : 'Nalezeno'),
+    activeFilters: t('events-active-filters', currentLang === 'en' ? 'Active filters' : 'Aktivní filtry'),
+    clearAll: t('events-clear-filters', currentLang === 'en' ? 'Clear all' : 'Vymazat vše'),
+    removeFilter: t('events-remove-filter', currentLang === 'en' ? 'Remove filter' : 'Odebrat filtr'),
+    nearMe: nearMeLabel(),
+    from: t('filters.from', currentLang === 'en' ? 'From' : 'Od'),
+    to: t('filters.to', currentLang === 'en' ? 'To' : 'Do'),
+    datePresets: {
+      today: t('filters.today', currentLang === 'en' ? 'Today' : 'Dnes'),
+      tomorrow: t('filters.tomorrow', currentLang === 'en' ? 'Tomorrow' : 'Zítra'),
+      thisWeek: t('filters.thisWeek', currentLang === 'en' ? 'This week' : 'Tento týden'),
+      weekend: t('filters.weekend', currentLang === 'en' ? 'This weekend' : 'Tento víkend')
+    },
+    categories: {
+      concert: t('category-concert', 'Koncerty'),
+      festival: t('category-festival', 'Festivaly'),
+      sport: t('category-sport', 'Sport'),
+      theatre: t('category-theatre', 'Divadlo')
+    },
+    sorts: {
+      latest: t('filters.latest', currentLang === 'en' ? 'Newest' : 'Nejnovější')
+    }
+  };
+}
+
 function computeActiveFiltersCount(filters = currentFilters) {
-  let count = 0;
-  if (filters.category && filters.category !== 'all') count++;
-  if (filters.city || filters.cityLabel || filters.placeType === 'country') count++;
-  if (filters.keyword) count++;
-  if (filters.sort && filters.sort !== 'nearest') count++;
-  if (filters.dateFrom || filters.dateTo) count++;
-  if (filters.nearMeLat && filters.nearMeLon) count++;
-  return count;
+  return getActiveFilterDescriptors(filters, {
+    locale: currentLang,
+    labels: getEventsFilterUxLabels()
+  }).length;
 }
 
 function updateToggleBadge() {
@@ -1653,6 +1698,112 @@ function updateToggleBadge() {
   btn.setAttribute('aria-label', cnt ? `${base} (${cnt})` : base);
 }
 
+function syncQuickDateButtons() {
+  const activePreset = detectDatePreset(currentFilters);
+
+  [
+    ['#chipToday', 'today'],
+    ['#chipTomorrow', 'tomorrow'],
+    ['#chipThisWeek', 'thisWeek'],
+    ['#chipWeekend', 'weekend']
+  ].forEach(([selector, preset]) => {
+    const button = qs(selector);
+    if (!button) return;
+
+    const active = activePreset === preset;
+    button.classList.toggle('is-active', active);
+    button.setAttribute('aria-pressed', active ? 'true' : 'false');
+  });
+}
+
+async function applyQuickDatePreset(preset) {
+  const activePreset = detectDatePreset(currentFilters);
+
+  if (activePreset === preset) {
+    currentFilters.dateFrom = '';
+    currentFilters.dateTo = '';
+  } else {
+    const range = getDatePresetRange(preset);
+    currentFilters.dateFrom = range.from;
+    currentFilters.dateTo = range.to;
+  }
+
+  _userInteractedWithFilters = true;
+  _lastFetchSig = '';
+  setFilterInputsFromState();
+  updateToggleBadge();
+  syncQuickDateButtons();
+  resetEventsPager();
+  await renderAndSync({ resetPage: true });
+}
+
+async function clearSingleEventFilter(key) {
+  switch (key) {
+    case 'category':
+      currentFilters.category = 'all';
+      break;
+
+    case 'place':
+      currentFilters.placeType = '';
+      currentFilters.city = '';
+      currentFilters.cityLabel = '';
+      currentFilters.cityCountryCode = '';
+      currentFilters.nearMeLat = null;
+      currentFilters.nearMeLon = null;
+      currentFilters.nearMeRadiusKm = 50;
+      currentFilters.countryCode = defaultCountryCodeForLang(currentLang);
+      break;
+
+    case 'date':
+      currentFilters.dateFrom = '';
+      currentFilters.dateTo = '';
+      break;
+
+    case 'keyword':
+      currentFilters.keyword = '';
+      break;
+
+    case 'sort':
+      currentFilters.sort = 'nearest';
+      break;
+
+    default:
+      return;
+  }
+
+  _userInteractedWithFilters = true;
+  _lastFetchSig = '';
+  setFilterInputsFromState();
+  updateToggleBadge();
+  syncQuickDateButtons();
+  resetEventsPager();
+  await renderAndSync({ resetPage: true });
+}
+
+async function resetAllEventFilters() {
+  currentFilters.category = 'all';
+  currentFilters.sort = 'nearest';
+  currentFilters.placeType = '';
+  currentFilters.city = '';
+  currentFilters.cityLabel = '';
+  currentFilters.cityCountryCode = '';
+  currentFilters.dateFrom = '';
+  currentFilters.dateTo = '';
+  currentFilters.keyword = '';
+  currentFilters.countryCode = defaultCountryCodeForLang(currentLang);
+  currentFilters.nearMeLat = null;
+  currentFilters.nearMeLon = null;
+  currentFilters.nearMeRadiusKm = 50;
+
+  _userInteractedWithFilters = true;
+  _lastFetchSig = '';
+  setFilterInputsFromState();
+  updateToggleBadge();
+  syncQuickDateButtons();
+  resetEventsPager();
+  await renderAndSync({ resetPage: true });
+}
+
 function updateResultsCount(n) {
   const host =
     qs('.events-upcoming-section .container') ||
@@ -1660,19 +1811,25 @@ function updateResultsCount(n) {
     (qs('#eventsList') ? qs('#eventsList').parentElement : null) ||
     document.body;
 
-  let el = host.querySelector('#eventsResultsCount');
-  if (!el) {
-    el = document.createElement('div');
-    el.id = 'eventsResultsCount';
-    el.className = 'events-results-count';
+  const list = qs('#eventsList');
 
-    const list = qs('#eventsList');
-    if (list && list.parentElement === host) host.insertBefore(el, list);
-    else host.appendChild(el);
-  }
+  renderEventsFilterSummary({
+    document,
+    host,
+    list,
+    count: n,
+    filters: currentFilters,
+    locale: currentLang,
+    labels: getEventsFilterUxLabels(),
+    onRemove: key => {
+      void clearSingleEventFilter(key);
+    },
+    onClear: () => {
+      void resetAllEventFilters();
+    }
+  });
 
-  const label = t('events-found', 'Nalezeno') || 'Nalezeno';
-  el.textContent = `${label}: ${n}`;
+  syncQuickDateButtons();
 }
 
 /* ───────── date range / combo label ───────── */
@@ -2062,6 +2219,29 @@ function bindFilterFormInteractions(formEl) {
     }, 'category-change');
   }
 
+  [
+    ['#chipToday', 'today'],
+    ['#chipTomorrow', 'tomorrow'],
+    ['#chipThisWeek', 'thisWeek'],
+    ['#chipWeekend', 'weekend']
+  ].forEach(([selector, preset]) => {
+    const button = qs(selector);
+    if (!button) return;
+
+    wireOnce(button, 'click', async () => {
+      await applyQuickDatePreset(preset);
+    }, `quick-date-${preset}`);
+  });
+
+  const clearQuickFilters = qs('#chipClear');
+  if (clearQuickFilters) {
+    wireOnce(clearQuickFilters, 'click', async () => {
+      await resetAllEventFilters();
+    }, 'quick-clear-all');
+  }
+
+  syncQuickDateButtons();
+
   wireOnce(formEl, 'submit', async e => {
     e.preventDefault();
     _userInteractedWithFilters = true;
@@ -2151,6 +2331,46 @@ function upgradeSortToSegmented() {
 }
 
 /* ───────── geolocation / Near Me ───────── */
+/* AJSEE_QUICK_NEAR_ME_BINDING_V1 */
+function bindQuickNearMeButton() {
+  const quickNearBtn = document.getElementById('chipNearMe');
+
+  if (!quickNearBtn) return;
+
+  wireOnce(quickNearBtn, 'click', async () => {
+    if (quickNearBtn.getAttribute('aria-busy') === 'true') {
+      return;
+    }
+
+    const cityInput = getCityInputEl();
+
+    _userInteractedWithFilters = true;
+
+    quickNearBtn.disabled = true;
+    quickNearBtn.setAttribute('aria-busy', 'true');
+
+    try {
+      await activateNearMeViaGeo(cityInput);
+
+      const isActive =
+        currentFilters.nearMeLat !== null &&
+        currentFilters.nearMeLat !== undefined &&
+        currentFilters.nearMeLon !== null &&
+        currentFilters.nearMeLon !== undefined;
+
+      quickNearBtn.setAttribute(
+        'aria-pressed',
+        String(isActive)
+      );
+
+      setFilterInputsFromState();
+      updateToggleBadge();
+    } finally {
+      quickNearBtn.disabled = false;
+      quickNearBtn.removeAttribute('aria-busy');
+    }
+  }, 'quick-near-me-click');
+}
 async function acquireGeolocation({ timeout = 15000, highAccuracy = false } = {}) {
   if (!('geolocation' in navigator)) {
     const err = new Error('no-geo');
@@ -4052,9 +4272,11 @@ async function bootstrapMain() {
   safeInitLangDropdown();
 
   const formEl = qs('#events-filters-form');
-  const topToolbar = document.querySelector('.filters-toolbar');
-  if (topToolbar) topToolbar.remove();
 
+  /* AJSEE_KEEP_EVENTS_QUICK_FILTERS_BOOTSTRAP_V1
+     Quick filters are permanent product UI and must remain
+     in the DOM throughout bootstrap.
+  */
   const legacyNearBtn = document.getElementById('filter-nearme');
   if (legacyNearBtn) legacyNearBtn.remove();
 
@@ -4062,6 +4284,7 @@ async function bootstrapMain() {
   normalizeFilterFormUI();
   installCitySheetObserver();
   bindFilterFormInteractions(formEl);
+  bindQuickNearMeButton();
 
   installDatePopoverScrollBridges();
   bindDatePopoverGlue();

--- a/src/events-filter-ux.js
+++ b/src/events-filter-ux.js
@@ -1,0 +1,313 @@
+// /src/events-filter-ux.js
+// AJSEE – reusable UX helpers for the events filter summary and date presets.
+
+function startOfLocalDay(value = new Date()) {
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function addDays(value, days) {
+  const date = new Date(value);
+  date.setDate(date.getDate() + days);
+  return date;
+}
+
+function toLocalIso(value) {
+  const date = startOfLocalDay(value);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function hasCoordinates(filters = {}) {
+  const lat = filters.nearMeLat;
+  const lon = filters.nearMeLon;
+
+  const hasLatValue =
+    lat !== null &&
+    lat !== undefined &&
+    lat !== '';
+
+  const hasLonValue =
+    lon !== null &&
+    lon !== undefined &&
+    lon !== '';
+
+  return hasLatValue &&
+    hasLonValue &&
+    Number.isFinite(Number(lat)) &&
+    Number.isFinite(Number(lon));
+}
+
+function formatIsoDate(value = '', locale = 'cs') {
+  if (!value) return '';
+
+  const date = new Date(`${value}T12:00:00`);
+
+  if (Number.isNaN(date.getTime())) return value;
+
+  try {
+    return new Intl.DateTimeFormat(locale || 'cs', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric'
+    }).format(date);
+  } catch {
+    return value;
+  }
+}
+
+export function getDatePresetRange(preset, now = new Date()) {
+  const today = startOfLocalDay(now);
+
+  if (preset === 'today') {
+    const iso = toLocalIso(today);
+    return { from: iso, to: iso };
+  }
+
+  if (preset === 'tomorrow') {
+    const tomorrow = addDays(today, 1);
+    const iso = toLocalIso(tomorrow);
+    return { from: iso, to: iso };
+  }
+
+  if (preset === 'thisWeek') {
+    const daysUntilSunday = (7 - today.getDay()) % 7;
+
+    return {
+      from: toLocalIso(today),
+      to: toLocalIso(addDays(today, daysUntilSunday))
+    };
+  }
+
+  if (preset === 'weekend') {
+    const day = today.getDay();
+
+    if (day === 6) {
+      return {
+        from: toLocalIso(today),
+        to: toLocalIso(addDays(today, 1))
+      };
+    }
+
+    if (day === 0) {
+      const iso = toLocalIso(today);
+      return { from: iso, to: iso };
+    }
+
+    const saturday = addDays(today, 6 - day);
+
+    return {
+      from: toLocalIso(saturday),
+      to: toLocalIso(addDays(saturday, 1))
+    };
+  }
+
+  return { from: '', to: '' };
+}
+
+export function detectDatePreset(filters = {}, now = new Date()) {
+  const from = String(filters.dateFrom || '');
+  const to = String(filters.dateTo || '');
+
+  for (const preset of ['today', 'tomorrow', 'weekend', 'thisWeek']) {
+    const range = getDatePresetRange(preset, now);
+
+    if (from === range.from && to === range.to) {
+      return preset;
+    }
+  }
+
+  return '';
+}
+
+export function getActiveFilterDescriptors(
+  filters = {},
+  {
+    locale = 'cs',
+    labels = {},
+    now = new Date()
+  } = {}
+) {
+  const descriptors = [];
+  const category = String(filters.category || 'all');
+
+  if (category !== 'all') {
+    descriptors.push({
+      key: 'category',
+      label: labels.categories?.[category] || category
+    });
+  }
+
+  const nearMe = hasCoordinates(filters);
+  const placeLabel = nearMe
+    ? String(labels.nearMe || filters.cityLabel || 'Near me').trim()
+    : String(
+      filters.cityLabel ||
+      filters.city ||
+      (filters.placeType === 'country'
+        ? labels.countries?.[filters.countryCode] || filters.countryCode || ''
+        : '')
+    ).trim();
+
+  if (placeLabel) {
+    descriptors.push({
+      key: 'place',
+      label: placeLabel
+    });
+  }
+
+  const dateFrom = String(filters.dateFrom || '');
+  const dateTo = String(filters.dateTo || '');
+
+  if (dateFrom || dateTo) {
+    const preset = detectDatePreset(filters, now);
+    let label = preset ? labels.datePresets?.[preset] : '';
+
+    if (!label) {
+      const fromLabel = formatIsoDate(dateFrom, locale);
+      const toLabel = formatIsoDate(dateTo, locale);
+
+      if (fromLabel && toLabel && dateFrom === dateTo) {
+        label = fromLabel;
+      } else if (fromLabel && toLabel) {
+        label = `${fromLabel} – ${toLabel}`;
+      } else if (fromLabel) {
+        label = `${labels.from || 'From'} ${fromLabel}`;
+      } else {
+        label = `${labels.to || 'To'} ${toLabel}`;
+      }
+    }
+
+    descriptors.push({
+      key: 'date',
+      label
+    });
+  }
+
+  const keyword = String(filters.keyword || '').trim();
+
+  if (keyword) {
+    descriptors.push({
+      key: 'keyword',
+      label: `“${keyword}”`
+    });
+  }
+
+  const sort = String(filters.sort || 'nearest');
+
+  if (sort !== 'nearest') {
+    descriptors.push({
+      key: 'sort',
+      label: labels.sorts?.[sort] || sort
+    });
+  }
+
+  return descriptors;
+}
+
+export function renderEventsFilterSummary({
+  document,
+  host,
+  list,
+  count,
+  filters = {},
+  locale = 'cs',
+  labels = {},
+  now = new Date(),
+  onRemove,
+  onClear
+} = {}) {
+  if (!document || !host) return null;
+
+  let root = host.querySelector('#eventsFilterSummary');
+
+  if (!root) {
+    root = document.createElement('section');
+    root.id = 'eventsFilterSummary';
+    root.className = 'events-filter-summary';
+
+    if (list && list.parentElement === host) {
+      host.insertBefore(root, list);
+    } else {
+      host.appendChild(root);
+    }
+  }
+
+  root.replaceChildren();
+
+  const descriptors = getActiveFilterDescriptors(filters, {
+    locale,
+    labels,
+    now
+  });
+
+  const top = document.createElement('div');
+  top.className = 'events-filter-summary__top';
+
+  const countElement = document.createElement('p');
+  countElement.id = 'eventsResultsCount';
+  countElement.className = 'events-results-count';
+  countElement.setAttribute('role', 'status');
+  countElement.setAttribute('aria-live', 'polite');
+  countElement.textContent = `${labels.found || 'Found'}: ${count}`;
+
+  top.appendChild(countElement);
+
+  if (descriptors.length) {
+    const clearButton = document.createElement('button');
+    clearButton.type = 'button';
+    clearButton.className = 'events-filter-summary__clear';
+    clearButton.textContent = labels.clearAll || 'Clear all';
+    clearButton.addEventListener('click', () => onClear?.());
+    top.appendChild(clearButton);
+  }
+
+  root.appendChild(top);
+
+  if (descriptors.length) {
+    const heading = document.createElement('span');
+    heading.className = 'sr-only';
+    heading.id = 'eventsActiveFiltersLabel';
+    heading.textContent = labels.activeFilters || 'Active filters';
+    root.appendChild(heading);
+
+    const listElement = document.createElement('div');
+    listElement.className = 'events-filter-summary__chips';
+    listElement.setAttribute('role', 'list');
+    listElement.setAttribute('aria-labelledby', heading.id);
+
+    descriptors.forEach((descriptor) => {
+      const item = document.createElement('span');
+      item.className = 'events-filter-summary__item';
+      item.setAttribute('role', 'listitem');
+
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'events-filter-chip';
+      button.setAttribute(
+        'aria-label',
+        `${labels.removeFilter || 'Remove filter'}: ${descriptor.label}`
+      );
+
+      const text = document.createElement('span');
+      text.textContent = descriptor.label;
+
+      const icon = document.createElement('span');
+      icon.className = 'events-filter-chip__remove';
+      icon.setAttribute('aria-hidden', 'true');
+      icon.textContent = '×';
+
+      button.append(text, icon);
+      button.addEventListener('click', () => onRemove?.(descriptor.key));
+      item.appendChild(button);
+      listElement.appendChild(item);
+    });
+
+    root.appendChild(listElement);
+  }
+
+  return root;
+}

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -190,7 +190,9 @@
     "geoDenied": "Přístup k poloze je zamítnut. Povolení můžete změnit v nastavení prohlížeče.",
     "geoTimeout": "Získání polohy trvalo příliš dlouho. Zkuste to prosím znovu.",
     "apply": "Použít filtry",
-    "reset": "Vymazat"
+    "reset": "Vymazat",
+    "tomorrow": "Zítra",
+    "thisWeek": "Tento týden"
   },
   "filter-category": "Kategorie",
   "filter-sort": "Řazení",
@@ -427,5 +429,12 @@
       "text": "Zažijte neopakovatelnou atmosféru West Endu. Vyberte si ze slavných světových muzikálů, pokračujte k nákupu vstupenek a rovnou k plánu přidejte i prověřené ubytování v Londýně.",
       "cta": "Prohlédnout muzikály"
     }
-  }
+  },
+  "events-found": "Nalezeno",
+  "events-active-filters": "Aktivní filtry",
+  "events-clear-filters": "Vymazat vše",
+  "events-remove-filter": "Odebrat filtr",
+  "events-empty-title": "Nenašli jsme žádné akce",
+  "events-empty-body": "Odeberte některý z aktivních filtrů nebo je všechny vymažte.",
+  "events-empty-clear": "Vymazat filtry"
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -191,7 +191,9 @@
     "geoDenied": "Zugriff auf Standort verweigert. Sie können die Berechtigung in den Browsereinstellungen ändern.",
     "geoTimeout": "Die Standortermittlung hat zu lange gedauert. Bitte erneut versuchen.",
     "apply": "Filter anwenden",
-    "reset": "Zurücksetzen"
+    "reset": "Zurücksetzen",
+    "tomorrow": "Morgen",
+    "thisWeek": "Diese Woche"
   },
   "filter-category": "Kategorie",
   "filter-sort": "Sortieren nach",
@@ -427,5 +429,12 @@
       "text": "Erleben Sie die unverwechselbare Atmosphäre des West End. Wählen Sie aus weltbekannten Musicals, gehen Sie weiter zu den Ticketoptionen und ergänzen Sie Ihre Planung um eine geprüfte Unterkunft in London.",
       "cta": "Musicals ansehen"
     }
-  }
+  },
+  "events-found": "Gefunden",
+  "events-active-filters": "Aktive Filter",
+  "events-clear-filters": "Alle löschen",
+  "events-remove-filter": "Filter entfernen",
+  "events-empty-title": "Keine Veranstaltungen gefunden",
+  "events-empty-body": "Entfernen Sie einen aktiven Filter oder löschen Sie alle Filter.",
+  "events-empty-clear": "Filter löschen"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -194,7 +194,9 @@
     "geoDenied": "Location access is denied. You can enable it in your browser settings.",
     "geoTimeout": "Getting location took too long. Please try again.",
     "apply": "Apply filters",
-    "reset": "Clear"
+    "reset": "Clear",
+    "tomorrow": "Tomorrow",
+    "thisWeek": "This week"
   },
   "filter-category": "Category",
   "filter-sort": "Sort by",
@@ -428,5 +430,11 @@
       "cta": "Browse musicals"
     }
   },
-  "events-found": "Found"
+  "events-found": "Found",
+  "events-active-filters": "Active filters",
+  "events-clear-filters": "Clear all",
+  "events-remove-filter": "Remove filter",
+  "events-empty-title": "No events found",
+  "events-empty-body": "Remove one of the active filters or clear them all.",
+  "events-empty-clear": "Clear filters"
 }

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -194,7 +194,9 @@
     "geoDenied": "A helyhozzáférés le van tiltva. A böngésző beállításaiban módosíthatod.",
     "geoTimeout": "A hely meghatározása túl sokáig tartott. Próbáld újra.",
     "apply": "Szűrők alkalmazása",
-    "reset": "Törlés"
+    "reset": "Törlés",
+    "tomorrow": "Holnap",
+    "thisWeek": "Ezen a héten"
   },
   "filter-category": "Kategória",
   "filter-sort": "Rendezés",
@@ -427,5 +429,12 @@
       "text": "Éld át a West End felejthetetlen hangulatát. Válassz a világhírű musicalek közül, nézd meg a jegyvásárlási lehetőségeket, és adj hozzá megbízható londoni szállást a tervedhez.",
       "cta": "Musicalek megtekintése"
     }
-  }
+  },
+  "events-found": "Találatok",
+  "events-active-filters": "Aktív szűrők",
+  "events-clear-filters": "Összes törlése",
+  "events-remove-filter": "Szűrő eltávolítása",
+  "events-empty-title": "Nem találtunk eseményeket",
+  "events-empty-body": "Távolítson el egy aktív szűrőt, vagy törölje az összeset.",
+  "events-empty-clear": "Szűrők törlése"
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -191,7 +191,9 @@
     "geoDenied": "Dostęp do lokalizacji jest zablokowany. Możesz zmienić uprawnienia w ustawieniach przeglądarki.",
     "geoTimeout": "Pobieranie lokalizacji trwało zbyt długo. Spróbuj ponownie.",
     "apply": "Zastosuj filtry",
-    "reset": "Wyczyść"
+    "reset": "Wyczyść",
+    "tomorrow": "Jutro",
+    "thisWeek": "W tym tygodniu"
   },
   "filter-category": "Kategoria",
   "filter-sort": "Sortowanie",
@@ -427,5 +429,12 @@
       "text": "Poczuj niepowtarzalną atmosferę West Endu. Wybierz spośród światowej sławy musicali, przejdź do opcji biletów i dodaj do planu sprawdzony nocleg w Londynie.",
       "cta": "Zobacz musicale"
     }
-  }
+  },
+  "events-found": "Znaleziono",
+  "events-active-filters": "Aktywne filtry",
+  "events-clear-filters": "Wyczyść wszystko",
+  "events-remove-filter": "Usuń filtr",
+  "events-empty-title": "Nie znaleziono wydarzeń",
+  "events-empty-body": "Usuń jeden z aktywnych filtrów albo wyczyść je wszystkie.",
+  "events-empty-clear": "Wyczyść filtry"
 }

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -191,7 +191,9 @@
     "geoDenied": "Prístup k polohe je zamietnutý. Povolenia môžete zmeniť v nastaveniach prehliadača.",
     "geoTimeout": "Získanie polohy trvalo príliš dlho. Skúste to prosím znova.",
     "apply": "Použiť filtre",
-    "reset": "Vymazať"
+    "reset": "Vymazať",
+    "tomorrow": "Zajtra",
+    "thisWeek": "Tento týždeň"
   },
   "filter-category": "Kategória",
   "filter-sort": "Triedenie",
@@ -427,5 +429,12 @@
       "text": "Zažite neopakovateľnú atmosféru West Endu. Vyberte si zo slávnych svetových muzikálov, pokračujte k nákupu vstupeniek a rovno si k plánu pridajte aj overené ubytovanie v Londýne.",
       "cta": "Prezrieť muzikály"
     }
-  }
+  },
+  "events-found": "Nájdené",
+  "events-active-filters": "Aktívne filtre",
+  "events-clear-filters": "Vymazať všetko",
+  "events-remove-filter": "Odstrániť filter",
+  "events-empty-title": "Nenašli sme žiadne podujatia",
+  "events-empty-body": "Odstráňte niektorý z aktívnych filtrov alebo ich všetky vymažte.",
+  "events-empty-clear": "Vymazať filtre"
 }

--- a/src/styles/partials/_filters-parity-final.scss
+++ b/src/styles/partials/_filters-parity-final.scss
@@ -142,8 +142,30 @@ html body[data-page="events"] main#main section#upcoming-events.events-upcoming-
     radial-gradient(100% 90% at 100% 0%, rgba(14, 136, 240, 0.08) 0%, rgba(14, 136, 240, 0) 42%);
 }
 
+/* AJSEE_EVENTS_QUICK_FILTERS_VISIBLE_V1 */
 html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar {
-  display: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 14px;
+  padding: 2px 2px 6px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
+html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar .chips {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar .chip {
+  flex: 0 0 auto;
+  min-height: 44px;
 }
 
 html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filter-group.native-date,
@@ -500,5 +522,226 @@ body[data-page="events"] #demoBadge.event-demo-badge {
   body[data-page="events"] #demoBadge.event-demo-badge {
     width: min(calc(100% - 32px), 100%);
     max-width: min(calc(100% - 32px), 100%);
+  }
+}
+
+/* AJSEE_EVENTS_FILTER_UX_V1 */
+html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar .chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-width: 0;
+}
+
+html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar .chip {
+  min-height: 40px;
+  padding: 0.58rem 0.9rem;
+  font-size: 0.88rem;
+}
+
+body[data-page="events"] .events-filter-summary {
+  width: min(calc(100% - 32px), 1100px);
+  margin: 0 auto 1.35rem;
+}
+
+body[data-page="events"] .events-filter-summary__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+body[data-page="events"] .events-results-count {
+  margin: 0;
+  color: #173a62;
+  font-size: clamp(1rem, 1.2vw, 1.12rem);
+  font-weight: 900;
+}
+
+body[data-page="events"] .events-filter-summary__clear {
+  min-height: 44px;
+  padding: 0.65rem 0.95rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: #0b5ed7;
+  font: inherit;
+  font-weight: 850;
+  cursor: pointer;
+}
+
+body[data-page="events"] .events-filter-summary__clear:hover {
+  background: rgba(14, 136, 240, 0.08);
+}
+
+body[data-page="events"] .events-filter-summary__clear:focus-visible,
+body[data-page="events"] .events-filter-chip:focus-visible {
+  outline: 3px solid rgba(14, 136, 240, 0.28);
+  outline-offset: 3px;
+}
+
+body[data-page="events"] .events-filter-summary__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+body[data-page="events"] .events-filter-summary__item {
+  display: inline-flex;
+}
+
+body[data-page="events"] .events-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 42px;
+  padding: 0.62rem 0.82rem 0.62rem 0.95rem;
+  border: 1px solid rgba(14, 136, 240, 0.2);
+  border-radius: 999px;
+  background: linear-gradient(180deg, #ffffff, #f4f9ff);
+  color: #173a62;
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(12, 36, 80, 0.06);
+}
+
+body[data-page="events"] .events-filter-chip:hover {
+  border-color: rgba(14, 136, 240, 0.38);
+  background: #eef7ff;
+}
+
+body[data-page="events"] .events-filter-chip__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(14, 136, 240, 0.1);
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+@media (max-width: 720px) {
+  html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar {
+    align-items: stretch;
+    overflow: hidden;
+  }
+
+  html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar .chips {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding: 2px 2px 8px;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section form#events-filters-form.events-filters.filter-dock .filters-toolbar #chipNearMe {
+    display: none;
+  }
+
+  body[data-page="events"] .events-filter-summary {
+    width: min(calc(100% - 32px), 1100px);
+  }
+
+  body[data-page="events"] .events-filter-summary__top {
+    align-items: flex-start;
+  }
+
+  body[data-page="events"] .events-filter-summary__chips {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding: 2px 2px 8px;
+    scrollbar-width: thin;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  body[data-page="events"] .events-filter-summary__item {
+    flex: 0 0 auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body[data-page="events"] .events-filter-chip,
+  body[data-page="events"] .events-filter-summary__clear {
+    transition: none;
+  }
+}
+/* AJSEE_EVENTS_MOBILE_QUICK_FILTER_LAYOUT_V2 */
+@media (max-width: 720px) {
+  html body[data-page="events"]
+  main#main
+  section#upcoming-events.events-upcoming-section
+  form#events-filters-form.events-filters.filter-dock
+  .filters-toolbar {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+    gap: 10px;
+    overflow: visible;
+    padding: 0;
+  }
+
+  html body[data-page="events"]
+  main#main
+  section#upcoming-events.events-upcoming-section
+  form#events-filters-form.events-filters.filter-dock
+  .filters-toolbar
+  .chips {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    width: 100%;
+    overflow: visible;
+    padding: 0;
+  }
+
+  html body[data-page="events"]
+  main#main
+  section#upcoming-events.events-upcoming-section
+  form#events-filters-form.events-filters.filter-dock
+  .filters-toolbar
+  .chips
+  .chip {
+    width: 100%;
+    min-width: 0;
+    min-height: 44px;
+    justify-content: center;
+    padding-inline: 0.65rem;
+    white-space: normal;
+    text-align: center;
+  }
+
+  html body[data-page="events"]
+  main#main
+  section#upcoming-events.events-upcoming-section
+  form#events-filters-form.events-filters.filter-dock
+  .filters-toolbar
+  #chipClear {
+    grid-column: 1 / -1;
+  }
+
+  html body[data-page="events"]
+  main#main
+  section#upcoming-events.events-upcoming-section
+  form#events-filters-form.events-filters.filter-dock
+  .filters-toolbar
+  #chipNearMe {
+    display: inline-flex !important;
+    width: 100%;
+    min-height: 48px;
+    align-items: center;
+    justify-content: center;
   }
 }

--- a/tests/events-filter-ux.test.mjs
+++ b/tests/events-filter-ux.test.mjs
@@ -1,0 +1,359 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+import {
+  detectDatePreset,
+  getActiveFilterDescriptors,
+  getDatePresetRange,
+  renderEventsFilterSummary
+} from '../src/events-filter-ux.js';
+
+test('tomorrow preset uses the next local calendar day', () => {
+  const now = new Date(2026, 7, 1, 12, 0, 0);
+
+  assert.deepEqual(
+    getDatePresetRange('tomorrow', now),
+    {
+      from: '2026-08-02',
+      to: '2026-08-02'
+    }
+  );
+});
+
+test('this week starts today and ends on Sunday', () => {
+  const now = new Date(2026, 7, 5, 12, 0, 0);
+
+  assert.deepEqual(
+    getDatePresetRange('thisWeek', now),
+    {
+      from: '2026-08-05',
+      to: '2026-08-09'
+    }
+  );
+});
+
+test('weekend preset keeps the current weekend when it is Saturday', () => {
+  const now = new Date(2026, 7, 1, 12, 0, 0);
+
+  assert.deepEqual(
+    getDatePresetRange('weekend', now),
+    {
+      from: '2026-08-01',
+      to: '2026-08-02'
+    }
+  );
+
+  assert.equal(
+    detectDatePreset(
+      {
+        dateFrom: '2026-08-01',
+        dateTo: '2026-08-02'
+      },
+      now
+    ),
+    'weekend'
+  );
+});
+
+test('null and empty near-me coordinates do not create an active place filter', () => {
+  const inactiveStates = [
+    {
+      nearMeLat: null,
+      nearMeLon: null
+    },
+    {
+      nearMeLat: '',
+      nearMeLon: ''
+    },
+    {
+      nearMeLat: undefined,
+      nearMeLon: undefined
+    }
+  ];
+
+  for (const state of inactiveStates) {
+    const descriptors = getActiveFilterDescriptors({
+      category: 'all',
+      sort: 'nearest',
+      placeType: '',
+      city: '',
+      cityLabel: '',
+      ...state
+    });
+
+    assert.deepEqual(descriptors, []);
+  }
+});
+
+test('near-me state produces only one place descriptor', () => {
+  const descriptors = getActiveFilterDescriptors(
+    {
+      placeType: 'nearMe',
+      cityLabel: 'V mém okolí',
+      nearMeLat: 48.85,
+      nearMeLon: 17.13,
+      nearMeRadiusKm: 50
+    },
+    {
+      labels: {
+        nearMe: 'V mém okolí'
+      }
+    }
+  );
+
+  assert.deepEqual(
+    descriptors,
+    [
+      {
+        key: 'place',
+        label: 'V mém okolí'
+      }
+    ]
+  );
+});
+
+test('active descriptor model includes category, place, date, keyword and sort', () => {
+  const now = new Date(2026, 7, 1, 12, 0, 0);
+
+  const descriptors = getActiveFilterDescriptors(
+    {
+      category: 'concert',
+      city: 'Praha',
+      cityLabel: 'Praha',
+      dateFrom: '2026-08-02',
+      dateTo: '2026-08-02',
+      keyword: 'jazz',
+      sort: 'latest'
+    },
+    {
+      locale: 'cs',
+      now,
+      labels: {
+        categories: {
+          concert: 'Koncerty'
+        },
+        datePresets: {
+          tomorrow: 'Zítra'
+        },
+        sorts: {
+          latest: 'Nejnovější'
+        }
+      }
+    }
+  );
+
+  assert.deepEqual(
+    descriptors,
+    [
+      { key: 'category', label: 'Koncerty' },
+      { key: 'place', label: 'Praha' },
+      { key: 'date', label: 'Zítra' },
+      { key: 'keyword', label: '“jazz”' },
+      { key: 'sort', label: 'Nejnovější' }
+    ]
+  );
+});
+
+test('summary renders accessible removable chips and clear-all action', () => {
+  const dom = new JSDOM(`
+    <!doctype html>
+    <html lang="cs">
+      <body>
+        <main id="host">
+          <div id="eventsList"></div>
+        </main>
+      </body>
+    </html>
+  `);
+
+  const removed = [];
+  let cleared = 0;
+
+  const document = dom.window.document;
+  const host = document.getElementById('host');
+  const list = document.getElementById('eventsList');
+
+  renderEventsFilterSummary({
+    document,
+    host,
+    list,
+    count: '20+',
+    filters: {
+      category: 'concert',
+      city: 'Praha',
+      cityLabel: 'Praha'
+    },
+    labels: {
+      found: 'Nalezeno',
+      activeFilters: 'Aktivní filtry',
+      clearAll: 'Vymazat vše',
+      removeFilter: 'Odebrat filtr',
+      categories: {
+        concert: 'Koncerty'
+      }
+    },
+    onRemove: (key) => removed.push(key),
+    onClear: () => {
+      cleared += 1;
+    }
+  });
+
+  assert.equal(
+    document.getElementById('eventsResultsCount').textContent,
+    'Nalezeno: 20+'
+  );
+
+  const buttons = [
+    ...document.querySelectorAll('.events-filter-chip')
+  ];
+
+  assert.equal(buttons.length, 2);
+  assert.equal(
+    buttons[0].getAttribute('aria-label'),
+    'Odebrat filtr: Koncerty'
+  );
+
+  buttons[0].click();
+  document.querySelector('.events-filter-summary__clear').click();
+
+  assert.deepEqual(removed, ['category']);
+  assert.equal(cleared, 1);
+});
+
+test('events page preserves the quick-filter toolbar', () => {
+  const source = readFileSync(
+    new URL('../src/events-entry.js', import.meta.url),
+    'utf8'
+  );
+
+  assert.match(
+    source,
+    /AJSEE_PRESERVE_EVENTS_QUICK_FILTERS_V1/
+  );
+
+  assert.doesNotMatch(
+    source,
+    /if\s*\(toolbar\)\s*toolbar\.remove\(\);/
+  );
+});
+
+test('events page exposes the quick-filter toolbar in final CSS', () => {
+  const source = readFileSync(
+    new URL(
+      '../src/styles/partials/_filters-parity-final.scss',
+      import.meta.url
+    ),
+    'utf8'
+  );
+
+  const selector =
+    'html body[data-page="events"] main#main ' +
+    'section#upcoming-events.events-upcoming-section ' +
+    'form#events-filters-form.events-filters.filter-dock ' +
+    '.filters-toolbar';
+
+  const start = source.indexOf(selector);
+
+  assert.notEqual(
+    start,
+    -1,
+    'Quick-filter toolbar selector must exist.'
+  );
+
+  const end = source.indexOf('}', start);
+  const block = source.slice(start, end + 1);
+
+  assert.match(
+    source,
+    /AJSEE_EVENTS_QUICK_FILTERS_VISIBLE_V1/
+  );
+
+  assert.match(
+    block,
+    /display:\s*flex;/
+  );
+
+  assert.doesNotMatch(
+    block,
+    /display:\s*none;/
+  );
+});
+
+test('bootstrap keeps the events quick-filter toolbar in the DOM', () => {
+  const source = readFileSync(
+    new URL('../src/events-entry.js', import.meta.url),
+    'utf8'
+  );
+
+  assert.match(
+    source,
+    /AJSEE_KEEP_EVENTS_QUICK_FILTERS_BOOTSTRAP_V1/
+  );
+
+  assert.doesNotMatch(
+    source,
+    /topToolbar\.remove\(\)/
+  );
+
+  assert.doesNotMatch(
+    source,
+    /if\s*\(topToolbar\)\s*topToolbar\.remove\(\)/
+  );
+});
+
+test('mobile quick filters expose all actions and bind near-me', () => {
+  const html = readFileSync(
+    new URL('../events.html', import.meta.url),
+    'utf8'
+  );
+
+  const entry = readFileSync(
+    new URL('../src/events-entry.js', import.meta.url),
+    'utf8'
+  );
+
+  const styles = readFileSync(
+    new URL(
+      '../src/styles/partials/_filters-parity-final.scss',
+      import.meta.url
+    ),
+    'utf8'
+  );
+
+  assert.match(
+    html,
+    /id="chipNearMe"[^>]*aria-pressed="false"/
+  );
+
+  assert.match(
+    entry,
+    /AJSEE_QUICK_NEAR_ME_BINDING_V1/
+  );
+
+  assert.match(
+    entry,
+    /bindQuickNearMeButton\(\);/
+  );
+
+  assert.match(
+    entry,
+    /wireOnce\(quickNearBtn,\s*'click'/
+  );
+
+  assert.match(
+    styles,
+    /AJSEE_EVENTS_MOBILE_QUICK_FILTER_LAYOUT_V2/
+  );
+
+  assert.match(
+    styles,
+    /grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)/
+  );
+
+  assert.match(
+    styles,
+    /#chipNearMe\s*\{[\s\S]*?display:\s*inline-flex\s*!important;/
+  );
+});


### PR DESCRIPTION
## Summary

Improves the event discovery experience by making commonly used filters faster, clearer and easier to manage across desktop and mobile.

## Changes

- adds quick date filters:
  - Today
  - Tomorrow
  - This week
  - This weekend
- adds active, removable filter chips
- adds a visible result count and clear-all action
- improves the no-results state
- preserves filters in the URL
- restores and connects the Near Me quick action
- introduces a mobile 2 × 2 quick-filter layout without hidden horizontal actions
- adds translations for CS, SK, EN, PL, HU and DE
- adds focused regression coverage for the filter UX

## Accessibility

- minimum 44 px mobile touch targets
- `aria-pressed` states for toggle actions
- accessible removable filter buttons
- loading state for geolocation
- keyboard-compatible native buttons

## Validation

- 11/11 focused event-filter tests passed
- 38/38 full regression tests passed
- production Vite build passed
- 359 build files generated
- tracked `dist` remained unchanged
- `git diff --check` passed

## Known non-blocking warnings

- existing Dart Sass deprecation warnings
- existing `/icons/calendar.svg` runtime resolution warning