### PR TITLE
Feat/events taxonomy filters v1

### DIFF
--- a/events.html
+++ b/events.html
@@ -271,6 +271,10 @@
               <button type="button" class="chip" id="chipTomorrow" data-i18n-key="filters.tomorrow" aria-pressed="false">Zítra</button>
               <button type="button" class="chip" id="chipThisWeek" data-i18n-key="filters.thisWeek" aria-pressed="false">Tento týden</button>
               <button type="button" class="chip" id="chipWeekend" data-i18n-key="filters.weekend" aria-pressed="false">Tento víkend</button>
+              <label class="chip family-audience-chip" for="filter-audience-family">
+                <input id="filter-audience-family" type="checkbox" name="audience" value="family" class="sr-only" />
+                <span data-i18n-key="filters.family">Pro rodiny</span>
+              </label>
               <button type="button" class="chip ghost" id="chipClear" data-i18n-key="filters.reset">Vymazat</button>
             </div>
             <button type="button" class="chip chip-near" id="chipNearMe" aria-pressed="false" aria-label="V mém okolí" data-i18n-aria="filters.nearMe" title="V mém okolí">
@@ -298,8 +302,9 @@
                 <option value="all" data-i18n-key="filters.all">Vše</option>
                 <option value="concert" data-i18n-key="category-concert">Koncerty</option>
                 <option value="festival" data-i18n-key="category-festival">Festivaly</option>
-                <option value="sport" data-i18n-key="category-sport">Sport</option>
                 <option value="theatre" data-i18n-key="category-theatre">Divadlo</option>
+                <option value="sport" data-i18n-key="category-sport">Sport</option>
+                <option value="film" data-i18n-key="category-film">Film a kino</option>
               </select>
             </div>
 

--- a/events.html
+++ b/events.html
@@ -271,10 +271,7 @@
               <button type="button" class="chip" id="chipTomorrow" data-i18n-key="filters.tomorrow" aria-pressed="false">Zítra</button>
               <button type="button" class="chip" id="chipThisWeek" data-i18n-key="filters.thisWeek" aria-pressed="false">Tento týden</button>
               <button type="button" class="chip" id="chipWeekend" data-i18n-key="filters.weekend" aria-pressed="false">Tento víkend</button>
-              <label class="chip family-audience-chip" for="filter-audience-family">
-                <input id="filter-audience-family" type="checkbox" name="audience" value="family" class="sr-only" />
-                <span data-i18n-key="filters.family">Pro rodiny</span>
-              </label>
+              <button type="button" class="chip family-audience-chip" id="filter-audience-family" data-i18n-key="filters.family" aria-pressed="false">Pro rodiny</button>
               <button type="button" class="chip ghost" id="chipClear" data-i18n-key="filters.reset">Vymazat</button>
             </div>
             <button type="button" class="chip chip-near" id="chipNearMe" aria-pressed="false" aria-label="V mém okolí" data-i18n-aria="filters.nearMe" title="V mém okolí">

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "reviews:build": "node scripts/build-reviews.mjs",
     "review-details:build": "node scripts/build-review-details.mjs",
     "review-details:localize": "cross-env REVIEW_LOCALIZE=1 node scripts/build-review-details.mjs",
-    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs tests/event-modal-ticket-options-dom.test.mjs tests/events-filter-ux.test.mjs tests/event-taxonomy.test.mjs tests/event-taxonomy-runtime.test.mjs",
+    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs tests/event-modal-ticket-options-dom.test.mjs tests/events-filter-ux.test.mjs tests/event-taxonomy.test.mjs tests/event-taxonomy-runtime.test.mjs tests/event-taxonomy-filters.test.mjs",
     "events:modal:test": "node --test --test-concurrency=1 tests/event-modal-ticket-options-dom.test.mjs",
     "events:filters:test": "node --test --test-concurrency=1 tests/events-filter-ux.test.mjs"
   },

--- a/src/adapters/smsticket.js
+++ b/src/adapters/smsticket.js
@@ -15,6 +15,10 @@ import {
   deriveLegacyCategory
 } from '../taxonomy/event-taxonomy.js';
 
+import {
+  matchesEventDiscoveryFilters
+} from '../taxonomy/event-filtering.js';
+
 const DEFAULT_DATA_URL = '/data/smsticket-events.json';
 
 // AJSEE_SMSTICKET_CITY_SUBSET_FEEDS_v1
@@ -458,15 +462,23 @@ export function withSmsticketTaxonomy(ev = {}) {
   };
 }
 
-function matchesCategory(ev, category = 'all') {
-  const wanted =
-    normalizeSmsticketCategory(
-      category
-    );
+function matchesDiscoveryFilters(
+  ev,
+  filters = {}
+) {
+  return matchesEventDiscoveryFilters(
+    ev,
+    {
+      category:
+        filters.category ??
+        filters.segment ??
+        'all',
 
-  if (wanted === 'all') return true;
-
-  return ev?.category === wanted;
+      audience:
+        filters.audience ??
+        ''
+    }
+  );
 }
 
 function matchesKeyword(ev, keyword = '') {
@@ -856,6 +868,7 @@ export async function fetchEvents({ filters = {} } = {}) {
   // searches usually reduce the candidate set the most.
   const city = filters.city || '';
   const category = filters.category ?? filters.segment ?? 'all';
+  const audience = filters.audience ?? '';
   const keyword = filters.keyword || '';
   const dateFrom = filters.dateFrom ?? filters.from ?? '';
   const dateTo = filters.dateTo ?? filters.to ?? '';
@@ -883,9 +896,12 @@ export async function fetchEvents({ filters = {} } = {}) {
       withSmsticketTaxonomy(ev);
 
     if (
-      !matchesCategory(
+      !matchesDiscoveryFilters(
         normalizedEvent,
-        category
+        {
+          category,
+          audience
+        }
       )
     ) {
       continue;

--- a/src/adapters/ticketmaster.js
+++ b/src/adapters/ticketmaster.js
@@ -808,28 +808,129 @@ function sortRawEvents(events = [], sort = 'date,asc', countryCode = '') {
   });
 }
 
-function getCategoryQueryVariants(category = 'all') {
-  const cat = String(category || 'all').trim().toLowerCase();
+function getCategoryQueryVariants(
+  category = 'all',
+  audience = ''
+) {
+  const cat =
+    String(
+      category ||
+      'all'
+    )
+      .trim()
+      .toLowerCase();
+
+  const familyAudience =
+    String(
+      audience ||
+      ''
+    )
+      .trim()
+      .toLowerCase() ===
+    'family';
+
+  let variants;
 
   switch (cat) {
     case 'concert':
-      return [{ segmentName: 'Music' }];
+      variants = [
+        {
+          segmentName:
+            'Music'
+        }
+      ];
+      break;
+
     case 'sport':
-      return [{ segmentName: 'Sports' }];
+      variants = [
+        {
+          segmentName:
+            'Sports'
+        }
+      ];
+      break;
+
     case 'theatre':
-      return [
-        { segmentName: 'Arts & Theatre' },
-        { classificationName: 'Theatre' }
+      variants = [
+        {
+          segmentName:
+            'Arts & Theatre'
+        },
+
+        {
+          classificationName:
+            'Theatre'
+        }
       ];
+      break;
+
     case 'festival':
-      return [
-        { classificationName: 'Festival' },
-        { segmentName: 'Music' }
+      variants = [
+        {
+          classificationName:
+            'Festival'
+        },
+
+        {
+          segmentName:
+            'Music'
+        }
       ];
+      break;
+
+    case 'film':
+      variants = [
+        {
+          classificationName:
+            'Film'
+        },
+
+        {
+          classificationName:
+            'Cinema'
+        }
+      ];
+      break;
+
     case 'all':
     default:
-      return [{}];
+      variants = [
+        {}
+      ];
+      break;
   }
+
+  if (
+    familyAudience &&
+    cat === 'all'
+  ) {
+    return [
+      {
+        classificationName:
+          'Family'
+      }
+    ];
+  }
+
+  if (familyAudience) {
+    return [
+      ...variants
+    ].sort(
+      (left, right) =>
+        Number(
+          Boolean(
+            left.classificationName
+          )
+        ) -
+        Number(
+          Boolean(
+            right.classificationName
+          )
+        )
+    );
+  }
+
+  return variants;
 }
 
 function categoryVariantKey(v = {}) {
@@ -1128,7 +1229,13 @@ export async function fetchEvents({ locale = 'cs', filters = {} } = {}) {
   const size = Number.isFinite(+filters.size) ? String(+filters.size) : '12';
 
   const category = filters.category || filters.segment || 'all';
-  const categoryVariants = getCategoryQueryVariants(category);
+
+  const categoryVariants =
+    getCategoryQueryVariants(
+      category,
+      filters.audience ||
+      ''
+    );
   const debugTm = shouldDebugTicketmaster(filters);
   const locales = makeLocaleList({
     marketLocale,
@@ -1143,6 +1250,25 @@ export async function fetchEvents({ locale = 'cs', filters = {} } = {}) {
     if (categoryVariant.segmentName) qs.set('segmentName', String(categoryVariant.segmentName));
     if (categoryVariant.classificationName) qs.set('classificationName', String(categoryVariant.classificationName));
     if (filters.classificationName) qs.set('classificationName', String(filters.classificationName));
+
+    if (
+      String(
+        filters.audience ||
+        ''
+      )
+        .trim()
+        .toLowerCase() ===
+        'family' &&
+      !qs.has(
+        'classificationName'
+      )
+    ) {
+      qs.set(
+        'classificationName',
+        'Family'
+      );
+    }
+
     if (filters.dateFrom) qs.set('dateFrom', String(filters.dateFrom));
     if (filters.dateTo) qs.set('dateTo', String(filters.dateTo));
 

--- a/src/api/eventsApi.js
+++ b/src/api/eventsApi.js
@@ -25,6 +25,7 @@ import { fetchEvents as fetchTicketmasterEvents } from '../adapters/ticketmaster
 import { fetchEvents as fetchSmsticketEvents } from '../adapters/smsticket.js';
 import { fetchEvents as fetchSeatPlanEvents } from '../adapters/seatplan.js';
 import { canonForInputCity, guessCountryCodeFromCity } from '../city/canonical.js';
+import { matchesEventDiscoveryFilters } from '../taxonomy/event-filtering.js';
 
 // DEV detekce (localhost/Vite)
 const isDev =
@@ -754,6 +755,7 @@ export async function fetchEvents({ locale, filters = {} } = {}) {
     dateFrom: filters.dateFrom ?? filters.from ?? '',
     dateTo: filters.dateTo ?? filters.to ?? '',
     category: filters.category ?? filters.segment ?? 'all',
+    audience: filters.audience ?? '',
     keyword: filters.keyword ?? filters.q ?? filters.search ?? '',
     // KlĂ­ÄŤovĂˇ zmÄ›na:
     // pokud uĹľivatel zadal "Francie", neposĂ­lĂˇme to dĂˇl jako city.
@@ -875,6 +877,7 @@ if (ENABLE_SEATPLAN) {
     dateFrom: filters.dateFrom ?? filters.from ?? '',
     dateTo: filters.dateTo ?? filters.to ?? '',
     category: filters.category ?? filters.segment ?? 'all',
+    audience: filters.audience ?? '',
     keyword: filters.keyword ?? filters.q ?? filters.search ?? '',
     // KlĂ­ÄŤovĂˇ zmÄ›na:
     // FE city filtr uĹľ nevidĂ­ "Francie" jako mÄ›sto.
@@ -886,6 +889,7 @@ if (ENABLE_SEATPLAN) {
 
   const {
     category = 'all',
+    audience = '',
     city = '',
     keyword = '',
     dateFrom = '',
@@ -916,10 +920,23 @@ if (ENABLE_SEATPLAN) {
     return true;
   });
 
-  if (category && category !== 'all') {
-    const want = normalizeStr(category);
-
-    all = all.filter((ev) => normalizeStr(ev.category) === want);
+  if (
+    (
+      category &&
+      category !== 'all'
+    ) ||
+    audience
+  ) {
+    all = all.filter(
+      (event) =>
+        matchesEventDiscoveryFilters(
+          event,
+          {
+            category,
+            audience
+          }
+        )
+    );
   }
 
   // Country-only ochrana:

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -2121,18 +2121,15 @@ function setFilterInputsFromState() {
       currentFilters.audience ===
       'family';
 
-    audience.checked =
-      active;
+    audience.setAttribute(
+      'aria-pressed',
+      String(active)
+    );
 
-    audience
-      .closest(
-        '.family-audience-chip'
-      )
-      ?.classList
-      .toggle(
-        'is-active',
-        active
-      );
+    audience.classList.toggle(
+      'is-active',
+      active
+    );
   }
 
   if (sort) {
@@ -2185,20 +2182,20 @@ function syncFiltersFromForm() {
     'all';
 
   if (audience) {
+    const active =
+      audience.getAttribute(
+        'aria-pressed'
+      ) === 'true';
+
     currentFilters.audience =
-      audience.checked
+      active
         ? 'family'
         : '';
 
-    audience
-      .closest(
-        '.family-audience-chip'
-      )
-      ?.classList
-      .toggle(
-        'is-active',
-        audience.checked
-      );
+    audience.classList.toggle(
+      'is-active',
+      active
+    );
   }
 
   currentFilters.sort =
@@ -2375,10 +2372,25 @@ function bindFilterFormInteractions(formEl) {
   if (audience) {
     wireOnce(
       audience,
-      'change',
+      'click',
       async () => {
         _userInteractedWithFilters =
           true;
+
+        const nextActive =
+          audience.getAttribute(
+            'aria-pressed'
+          ) !== 'true';
+
+        audience.setAttribute(
+          'aria-pressed',
+          String(nextActive)
+        );
+
+        audience.classList.toggle(
+          'is-active',
+          nextActive
+        );
 
         syncFiltersFromForm();
         resetEventsPager();
@@ -2388,7 +2400,7 @@ function bindFilterFormInteractions(formEl) {
             true
         });
       },
-      'family-audience-change'
+      'family-audience-click'
     );
   }
 

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -91,6 +91,7 @@ const SUPPORTED_COUNTRY_CODES = new Set([
 
 let currentFilters = {
   category: 'all',
+  audience: '',
   sort: 'nearest',
   placeType: '',
   city: '',
@@ -1662,11 +1663,49 @@ function getEventsFilterUxLabels() {
       weekend: t('filters.weekend', currentLang === 'en' ? 'This weekend' : 'Tento víkend')
     },
     categories: {
-      concert: t('category-concert', 'Koncerty'),
-      festival: t('category-festival', 'Festivaly'),
-      sport: t('category-sport', 'Sport'),
-      theatre: t('category-theatre', 'Divadlo')
+      concert:
+        t(
+          'category-concert',
+          'Koncerty'
+        ),
+
+      festival:
+        t(
+          'category-festival',
+          'Festivaly'
+        ),
+
+      theatre:
+        t(
+          'category-theatre',
+          'Divadlo'
+        ),
+
+      sport:
+        t(
+          'category-sport',
+          'Sport'
+        ),
+
+      film:
+        t(
+          'category-film',
+          currentLang === 'en'
+            ? 'Film & cinema'
+            : 'Film a kino'
+        )
     },
+
+    audiences: {
+      family:
+        t(
+          'filters.family',
+          currentLang === 'en'
+            ? 'Family-friendly'
+            : 'Pro rodiny'
+        )
+    },
+
     sorts: {
       latest: t('filters.latest', currentLang === 'en' ? 'Newest' : 'Nejnovější')
     }
@@ -1743,6 +1782,10 @@ async function clearSingleEventFilter(key) {
       currentFilters.category = 'all';
       break;
 
+    case 'audience':
+      currentFilters.audience = '';
+      break;
+
     case 'place':
       currentFilters.placeType = '';
       currentFilters.city = '';
@@ -1782,6 +1825,7 @@ async function clearSingleEventFilter(key) {
 
 async function resetAllEventFilters() {
   currentFilters.category = 'all';
+  currentFilters.audience = '';
   currentFilters.sort = 'nearest';
   currentFilters.placeType = '';
   currentFilters.city = '';
@@ -2047,15 +2091,55 @@ function bindDatePopoverGlue() {
 
 /* ───────── form sync / URL sync ───────── */
 function setFilterInputsFromState() {
-  const cat = qs('#filter-category') || qs('#events-category-filter');
-  const sort = qs('#filter-sort') || qs('#events-sort-filter');
-  const city = getCityInputEl();
+  const cat =
+    qs('#filter-category') ||
+    qs('#events-category-filter');
+
+  const audience =
+    qs(
+      '#filter-audience-family'
+    );
+
+  const sort =
+    qs('#filter-sort') ||
+    qs('#events-sort-filter');
+
+  const city =
+    getCityInputEl();
   const from = qs('#filter-date-from') || qs('#events-date-from');
   const to = qs('#filter-date-to') || qs('#events-date-to');
   const kw = qs('#filter-keyword');
 
-  if (cat) cat.value = currentFilters.category || 'all';
-  if (sort) sort.value = currentFilters.sort || 'nearest';
+  if (cat) {
+    cat.value =
+      currentFilters.category ||
+      'all';
+  }
+
+  if (audience) {
+    const active =
+      currentFilters.audience ===
+      'family';
+
+    audience.checked =
+      active;
+
+    audience
+      .closest(
+        '.family-audience-chip'
+      )
+      ?.classList
+      .toggle(
+        'is-active',
+        active
+      );
+  }
+
+  if (sort) {
+    sort.value =
+      currentFilters.sort ||
+      'nearest';
+  }
 
   if (city) {
     if (currentFilters.nearMeLat && currentFilters.nearMeLon) {
@@ -2077,15 +2161,49 @@ function setFilterInputsFromState() {
 }
 
 function syncFiltersFromForm() {
-  const cat = qs('#filter-category') || qs('#events-category-filter');
-  const sort = qs('#filter-sort') || qs('#events-sort-filter');
-  const city = getCityInputEl();
+  const cat =
+    qs('#filter-category') ||
+    qs('#events-category-filter');
+
+  const audience =
+    qs(
+      '#filter-audience-family'
+    );
+
+  const sort =
+    qs('#filter-sort') ||
+    qs('#events-sort-filter');
+
+  const city =
+    getCityInputEl();
   const from = qs('#filter-date-from') || qs('#events-date-from');
   const to = qs('#filter-date-to') || qs('#events-date-to');
   const kw = qs('#filter-keyword');
 
-  currentFilters.category = cat?.value || 'all';
-  currentFilters.sort = sort?.value || 'nearest';
+  currentFilters.category =
+    cat?.value ||
+    'all';
+
+  if (audience) {
+    currentFilters.audience =
+      audience.checked
+        ? 'family'
+        : '';
+
+    audience
+      .closest(
+        '.family-audience-chip'
+      )
+      ?.classList
+      .toggle(
+        'is-active',
+        audience.checked
+      );
+  }
+
+  currentFilters.sort =
+    sort?.value ||
+    'nearest';
   currentFilters.keyword = (kw?.value || '').trim();
   currentFilters.dateFrom = from?.value || currentFilters.dateFrom || '';
   currentFilters.dateTo = to?.value || currentFilters.dateTo || '';
@@ -2151,6 +2269,11 @@ function syncURLFromFilters() {
   currentFilters.dateFrom ? p.set('from', currentFilters.dateFrom) : p.delete('from');
   currentFilters.dateTo ? p.set('to', currentFilters.dateTo) : p.delete('to');
   (currentFilters.category && currentFilters.category !== 'all') ? p.set('segment', currentFilters.category) : p.delete('segment');
+
+  currentFilters.audience === 'family'
+    ? p.set('audience', 'family')
+    : p.delete('audience');
+
   p.delete('keyword');
   p.delete('search');
   currentFilters.keyword ? p.set('q', currentFilters.keyword) : p.delete('q');
@@ -2188,7 +2311,18 @@ function initFiltersFromURL() {
 
   if (sp.get('from')) currentFilters.dateFrom = sp.get('from') || '';
   if (sp.get('to')) currentFilters.dateTo = sp.get('to') || '';
-  if (sp.get('segment')) currentFilters.category = sp.get('segment') || 'all';
+  if (sp.get('segment')) {
+    currentFilters.category =
+      sp.get('segment') ||
+      'all';
+  }
+
+  currentFilters.audience =
+    sp.get('audience') ===
+    'family'
+      ? 'family'
+      : '';
+
   const urlKeyword = sp.get('q') || sp.get('keyword') || sp.get('search') || '';
   if (urlKeyword) currentFilters.keyword = urlKeyword.trim();
   if (sp.get('sort')) currentFilters.sort = sp.get('sort') || 'nearest';
@@ -2209,14 +2343,53 @@ function initFiltersFromURL() {
 function bindFilterFormInteractions(formEl) {
   if (!formEl) return;
 
-  const category = qs('#filter-category') || qs('#events-category-filter');
+  const category =
+    qs('#filter-category') ||
+    qs('#events-category-filter');
+
   if (category) {
-    wireOnce(category, 'change', async () => {
-      _userInteractedWithFilters = true;
-      syncFiltersFromForm();
-      resetEventsPager();
-      await renderAndSync({ resetPage: true });
-    }, 'category-change');
+    wireOnce(
+      category,
+      'change',
+      async () => {
+        _userInteractedWithFilters =
+          true;
+
+        syncFiltersFromForm();
+        resetEventsPager();
+
+        await renderAndSync({
+          resetPage:
+            true
+        });
+      },
+      'category-change'
+    );
+  }
+
+  const audience =
+    qs(
+      '#filter-audience-family'
+    );
+
+  if (audience) {
+    wireOnce(
+      audience,
+      'change',
+      async () => {
+        _userInteractedWithFilters =
+          true;
+
+        syncFiltersFromForm();
+        resetEventsPager();
+
+        await renderAndSync({
+          resetPage:
+            true
+        });
+      },
+      'family-audience-change'
+    );
   }
 
   [

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -3980,7 +3980,13 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
 
     let out = [...eventsPager.buffer];
 
-    if (filters.category && filters.category !== 'all') out = out.filter(e => e.category === filters.category);
+    /*
+     * Category and audience filtering is already applied by
+     * eventsApi through the shared taxonomy matcher before
+     * pagination. Do not re-filter the returned events by the
+     * legacy event.category value here: film and expanded sport
+     * results intentionally retain their original legacy category.
+     */
 
     if (!shouldPreserveSeatPlanApiOrder(api, out)) {
       if (filters.sort === 'nearest') out.sort((a, b) => new Date(a.datetime || a.date) - new Date(b.datetime || b.date));

--- a/src/events-filter-ux.js
+++ b/src/events-filter-ux.js
@@ -141,6 +141,28 @@ export function getActiveFilterDescriptors(
     });
   }
 
+  const audience =
+    String(
+      filters.audience ||
+      ''
+    ).trim();
+
+  if (
+    audience &&
+    audience !== 'all'
+  ) {
+    descriptors.push({
+      key:
+        'audience',
+
+      label:
+        labels.audiences?.[
+          audience
+        ] ||
+        audience
+    });
+  }
+
   const nearMe = hasCoordinates(filters);
   const placeLabel = nearMe
     ? String(labels.nearMe || filters.cityLabel || 'Near me').trim()

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -192,7 +192,9 @@
     "apply": "Použít filtry",
     "reset": "Vymazat",
     "tomorrow": "Zítra",
-    "thisWeek": "Tento týden"
+    "thisWeek": "Tento týden",
+    "film": "Film a kino",
+    "family": "Pro rodiny"
   },
   "filter-category": "Kategorie",
   "filter-sort": "Řazení",
@@ -436,5 +438,6 @@
   "events-remove-filter": "Odebrat filtr",
   "events-empty-title": "Nenašli jsme žádné akce",
   "events-empty-body": "Odeberte některý z aktivních filtrů nebo je všechny vymažte.",
-  "events-empty-clear": "Vymazat filtry"
+  "events-empty-clear": "Vymazat filtry",
+  "category-film": "Film a kino"
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -193,7 +193,9 @@
     "apply": "Filter anwenden",
     "reset": "Zurücksetzen",
     "tomorrow": "Morgen",
-    "thisWeek": "Diese Woche"
+    "thisWeek": "Diese Woche",
+    "film": "Film & Kino",
+    "family": "Für Familien"
   },
   "filter-category": "Kategorie",
   "filter-sort": "Sortieren nach",
@@ -436,5 +438,6 @@
   "events-remove-filter": "Filter entfernen",
   "events-empty-title": "Keine Veranstaltungen gefunden",
   "events-empty-body": "Entfernen Sie einen aktiven Filter oder löschen Sie alle Filter.",
-  "events-empty-clear": "Filter löschen"
+  "events-empty-clear": "Filter löschen",
+  "category-film": "Film & Kino"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -196,7 +196,9 @@
     "apply": "Apply filters",
     "reset": "Clear",
     "tomorrow": "Tomorrow",
-    "thisWeek": "This week"
+    "thisWeek": "This week",
+    "film": "Film & cinema",
+    "family": "Family-friendly"
   },
   "filter-category": "Category",
   "filter-sort": "Sort by",
@@ -436,5 +438,6 @@
   "events-remove-filter": "Remove filter",
   "events-empty-title": "No events found",
   "events-empty-body": "Remove one of the active filters or clear them all.",
-  "events-empty-clear": "Clear filters"
+  "events-empty-clear": "Clear filters",
+  "category-film": "Film & cinema"
 }

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -196,7 +196,9 @@
     "apply": "Szűrők alkalmazása",
     "reset": "Törlés",
     "tomorrow": "Holnap",
-    "thisWeek": "Ezen a héten"
+    "thisWeek": "Ezen a héten",
+    "film": "Film és mozi",
+    "family": "Családoknak"
   },
   "filter-category": "Kategória",
   "filter-sort": "Rendezés",
@@ -436,5 +438,6 @@
   "events-remove-filter": "Szűrő eltávolítása",
   "events-empty-title": "Nem találtunk eseményeket",
   "events-empty-body": "Távolítson el egy aktív szűrőt, vagy törölje az összeset.",
-  "events-empty-clear": "Szűrők törlése"
+  "events-empty-clear": "Szűrők törlése",
+  "category-film": "Film és mozi"
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -193,7 +193,9 @@
     "apply": "Zastosuj filtry",
     "reset": "Wyczyść",
     "tomorrow": "Jutro",
-    "thisWeek": "W tym tygodniu"
+    "thisWeek": "W tym tygodniu",
+    "film": "Film i kino",
+    "family": "Dla rodzin"
   },
   "filter-category": "Kategoria",
   "filter-sort": "Sortowanie",
@@ -436,5 +438,6 @@
   "events-remove-filter": "Usuń filtr",
   "events-empty-title": "Nie znaleziono wydarzeń",
   "events-empty-body": "Usuń jeden z aktywnych filtrów albo wyczyść je wszystkie.",
-  "events-empty-clear": "Wyczyść filtry"
+  "events-empty-clear": "Wyczyść filtry",
+  "category-film": "Film i kino"
 }

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -193,7 +193,9 @@
     "apply": "Použiť filtre",
     "reset": "Vymazať",
     "tomorrow": "Zajtra",
-    "thisWeek": "Tento týždeň"
+    "thisWeek": "Tento týždeň",
+    "film": "Film a kino",
+    "family": "Pre rodiny"
   },
   "filter-category": "Kategória",
   "filter-sort": "Triedenie",
@@ -436,5 +438,6 @@
   "events-remove-filter": "Odstrániť filter",
   "events-empty-title": "Nenašli sme žiadne podujatia",
   "events-empty-body": "Odstráňte niektorý z aktívnych filtrov alebo ich všetky vymažte.",
-  "events-empty-clear": "Vymazať filtre"
+  "events-empty-clear": "Vymazať filtre",
+  "category-film": "Film a kino"
 }

--- a/src/styles/partials/_filters-parity-final.scss
+++ b/src/styles/partials/_filters-parity-final.scss
@@ -745,37 +745,3 @@ body[data-page="events"] .events-filter-chip__remove {
     justify-content: center;
   }
 }
-
- /* AJSEE_EVENTS_FAMILY_AUDIENCE_FILTER_V1 */
-html body[data-page="events"]
-main#main
-section#upcoming-events.events-upcoming-section
-form#events-filters-form.events-filters.filter-dock
-.family-audience-chip {
-  position: relative;
-  user-select: none;
-}
-
-html body[data-page="events"]
-main#main
-section#upcoming-events.events-upcoming-section
-form#events-filters-form.events-filters.filter-dock
-.family-audience-chip:focus-within {
-  outline: 3px solid rgba(14, 136, 240, 0.34);
-  outline-offset: 2px;
-}
-
-html body[data-page="events"]
-main#main
-section#upcoming-events.events-upcoming-section
-form#events-filters-form.events-filters.filter-dock
-.family-audience-chip.is-active {
-  color: #0d4f78;
-  border-color: rgba(14, 136, 240, 0.34);
-  background:
-    linear-gradient(
-      135deg,
-      rgba(20, 194, 197, 0.18),
-      rgba(14, 136, 240, 0.14)
-    );
-}

--- a/src/styles/partials/_filters-parity-final.scss
+++ b/src/styles/partials/_filters-parity-final.scss
@@ -745,3 +745,37 @@ body[data-page="events"] .events-filter-chip__remove {
     justify-content: center;
   }
 }
+
+ /* AJSEE_EVENTS_FAMILY_AUDIENCE_FILTER_V1 */
+html body[data-page="events"]
+main#main
+section#upcoming-events.events-upcoming-section
+form#events-filters-form.events-filters.filter-dock
+.family-audience-chip {
+  position: relative;
+  user-select: none;
+}
+
+html body[data-page="events"]
+main#main
+section#upcoming-events.events-upcoming-section
+form#events-filters-form.events-filters.filter-dock
+.family-audience-chip:focus-within {
+  outline: 3px solid rgba(14, 136, 240, 0.34);
+  outline-offset: 2px;
+}
+
+html body[data-page="events"]
+main#main
+section#upcoming-events.events-upcoming-section
+form#events-filters-form.events-filters.filter-dock
+.family-audience-chip.is-active {
+  color: #0d4f78;
+  border-color: rgba(14, 136, 240, 0.34);
+  background:
+    linear-gradient(
+      135deg,
+      rgba(20, 194, 197, 0.18),
+      rgba(14, 136, 240, 0.14)
+    );
+}

--- a/src/taxonomy/event-filtering.js
+++ b/src/taxonomy/event-filtering.js
@@ -1,0 +1,190 @@
+// /src/taxonomy/event-filtering.js
+// AJSEE – shared taxonomy-aware event filtering helpers.
+
+function text(value) {
+  if (value == null) return '';
+
+  return String(value).trim();
+}
+
+function fold(value) {
+  return text(value)
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function values(value) {
+  return Array.isArray(value)
+    ? value
+        .map(fold)
+        .filter(Boolean)
+    : [];
+}
+
+export function normalizeEventCategoryFilter(
+  value = 'all'
+) {
+  const normalized =
+    fold(
+      value ||
+      'all'
+    );
+
+  switch (normalized) {
+    case '':
+    case 'all':
+      return 'all';
+
+    case 'sports':
+      return 'sport';
+
+    case 'cinema':
+    case 'movie':
+    case 'movies':
+      return 'film';
+
+    default:
+      return normalized;
+  }
+}
+
+export function normalizeEventAudienceFilter(
+  value = ''
+) {
+  const normalized =
+    fold(value);
+
+  switch (normalized) {
+    case '':
+    case 'all':
+      return '';
+
+    case 'children':
+    case 'kids':
+      return 'family';
+
+    default:
+      return normalized;
+  }
+}
+
+export function matchesEventCategoryFilter(
+  event = {},
+  category = 'all'
+) {
+  const wanted =
+    normalizeEventCategoryFilter(
+      category
+    );
+
+  if (wanted === 'all') {
+    return true;
+  }
+
+  const legacyCategory =
+    normalizeEventCategoryFilter(
+      event.category ||
+      ''
+    );
+
+  const domains =
+    values(
+      event.taxonomy?.domains
+    );
+
+  const eventTypes =
+    values(
+      event.taxonomy?.eventTypes
+    );
+
+  if (wanted === 'film') {
+    return (
+      legacyCategory === 'film' ||
+      domains.includes('film') ||
+      eventTypes.includes('cinema')
+    );
+  }
+
+  if (wanted === 'sport') {
+    return (
+      legacyCategory === 'sport' ||
+      domains.includes('sport')
+    );
+  }
+
+  /*
+   * Concert, festival and theatre intentionally retain
+   * the existing legacy category semantics in filter v1.
+   *
+   * Their taxonomy domains currently overlap too broadly
+   * for a safe public filter migration.
+   */
+  return (
+    legacyCategory ===
+    wanted
+  );
+}
+
+export function matchesEventAudienceFilter(
+  event = {},
+  audience = ''
+) {
+  const wanted =
+    normalizeEventAudienceFilter(
+      audience
+    );
+
+  if (!wanted) {
+    return true;
+  }
+
+  const audiences =
+    values(
+      event.taxonomy?.audiences
+    );
+
+  const legacyCategory =
+    normalizeEventCategoryFilter(
+      event.category ||
+      ''
+    );
+
+  if (wanted === 'family') {
+    return (
+      audiences.includes('family') ||
+      legacyCategory === 'family'
+    );
+  }
+
+  return audiences.includes(
+    wanted
+  );
+}
+
+export function matchesEventDiscoveryFilters(
+  event = {},
+  filters = {}
+) {
+  const category =
+    filters.category ??
+    filters.segment ??
+    'all';
+
+  const audience =
+    filters.audience ??
+    '';
+
+  return (
+    matchesEventCategoryFilter(
+      event,
+      category
+    ) &&
+    matchesEventAudienceFilter(
+      event,
+      audience
+    )
+  );
+}

--- a/tests/event-taxonomy-filters.test.mjs
+++ b/tests/event-taxonomy-filters.test.mjs
@@ -1,0 +1,512 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+  matchesEventAudienceFilter,
+  matchesEventCategoryFilter,
+  matchesEventDiscoveryFilters
+} from '../src/taxonomy/event-filtering.js';
+
+import {
+  fetchEvents as fetchSmsticketEvents
+} from '../src/adapters/smsticket.js';
+
+import {
+  mapTicketmasterEvent
+} from '../src/adapters/ticketmaster.js';
+
+test(
+  'legacy concert, festival and theatre filters keep exact category semantics',
+  () => {
+    const party = {
+      category: 'concert',
+
+      taxonomy: {
+        domains: ['music'],
+        eventTypes: ['party'],
+        audiences: []
+      }
+    };
+
+    const otherShow = {
+      category: 'other',
+
+      taxonomy: {
+        domains: ['stage'],
+        eventTypes: ['show'],
+        audiences: []
+      }
+    };
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        party,
+        'concert'
+      ),
+      true
+    );
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        otherShow,
+        'theatre'
+      ),
+      false
+    );
+  }
+);
+
+test(
+  'film filter uses taxonomy without changing the legacy category',
+  () => {
+    const event = {
+      category: 'other',
+
+      taxonomy: {
+        domains: ['film'],
+        eventTypes: ['cinema'],
+        audiences: []
+      }
+    };
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        event,
+        'film'
+      ),
+      true
+    );
+
+    assert.equal(
+      event.category,
+      'other'
+    );
+  }
+);
+
+test(
+  'sport filter includes taxonomy sport events from other legacy categories',
+  () => {
+    const event = {
+      category: 'festival',
+
+      taxonomy: {
+        domains: [
+          'music',
+          'sport'
+        ],
+
+        eventTypes: [
+          'festival',
+          'competition'
+        ],
+
+        audiences: []
+      }
+    };
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        event,
+        'sport'
+      ),
+      true
+    );
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        event,
+        'festival'
+      ),
+      true
+    );
+  }
+);
+
+test(
+  'family audience is independent and can be combined with a category',
+  () => {
+    const familyFestival = {
+      category: 'festival',
+
+      taxonomy: {
+        domains: [
+          'music',
+          'experience'
+        ],
+
+        eventTypes: [
+          'festival'
+        ],
+
+        audiences: [
+          'family'
+        ]
+      }
+    };
+
+    assert.equal(
+      matchesEventAudienceFilter(
+        familyFestival,
+        'family'
+      ),
+      true
+    );
+
+    assert.equal(
+      matchesEventDiscoveryFilters(
+        familyFestival,
+        {
+          category: 'festival',
+          audience: 'family'
+        }
+      ),
+      true
+    );
+
+    assert.equal(
+      matchesEventDiscoveryFilters(
+        familyFestival,
+        {
+          category: 'theatre',
+          audience: 'family'
+        }
+      ),
+      false
+    );
+  }
+);
+
+test(
+  'SMS Ticket filters film, expanded sport and family before pagination',
+  async (t) => {
+    const originalFetch =
+      globalThis.fetch;
+
+    const fixtureEvents = [
+      {
+        id:
+          'sms-film',
+
+        category:
+          'other',
+
+        date:
+          '2099-08-01',
+
+        datetime:
+          '2099-08-01T18:00:00',
+
+        title: {
+          cs:
+            'Letní kino'
+        },
+
+        categories: [
+          'Film'
+        ],
+
+        types: [
+          'Kino / Projekce'
+        ]
+      },
+
+      {
+        id:
+          'sms-sport-festival',
+
+        category:
+          'sports',
+
+        date:
+          '2099-08-02',
+
+        datetime:
+          '2099-08-02T18:00:00',
+
+        title: {
+          cs:
+            'Sportovní festival'
+        },
+
+        categories: [
+          'Sport'
+        ],
+
+        types: [
+          'Festival',
+          'Soutěž / Zápas / Závod'
+        ]
+      },
+
+      {
+        id:
+          'sms-family-festival',
+
+        category:
+          'family',
+
+        date:
+          '2099-08-03',
+
+        datetime:
+          '2099-08-03T18:00:00',
+
+        title: {
+          cs:
+            'Rodinný festival'
+        },
+
+        categories: [
+          'Děti'
+        ],
+
+        types: [
+          'Festival'
+        ]
+      },
+
+      {
+        id:
+          'sms-family-theatre',
+
+        category:
+          'family',
+
+        date:
+          '2099-08-04',
+
+        datetime:
+          '2099-08-04T18:00:00',
+
+        title: {
+          cs:
+            'Rodinné divadlo'
+        },
+
+        categories: [
+          'Představení',
+          'Děti'
+        ],
+
+        types: [
+          'Divadlo'
+        ]
+      }
+    ];
+
+    globalThis.fetch =
+      async () => ({
+        ok: true,
+
+        async json() {
+          return {
+            events:
+              fixtureEvents
+          };
+        }
+      });
+
+    t.after(() => {
+      globalThis.fetch =
+        originalFetch;
+    });
+
+    const film =
+      await fetchSmsticketEvents({
+        filters: {
+          category: 'film',
+          page: 0,
+          size: 50
+        }
+      });
+
+    assert.deepEqual(
+      film.map(
+        (event) =>
+          event.id
+      ),
+      [
+        'sms-film'
+      ]
+    );
+
+    const sport =
+      await fetchSmsticketEvents({
+        filters: {
+          category: 'sport',
+          page: 0,
+          size: 50
+        }
+      });
+
+    assert.deepEqual(
+      sport.map(
+        (event) =>
+          event.id
+      ),
+      [
+        'sms-sport-festival'
+      ]
+    );
+
+    const family =
+      await fetchSmsticketEvents({
+        filters: {
+          audience: 'family',
+          page: 0,
+          size: 50
+        }
+      });
+
+    assert.deepEqual(
+      family.map(
+        (event) =>
+          event.id
+      ),
+      [
+        'sms-family-festival',
+        'sms-family-theatre'
+      ]
+    );
+
+    const familyFestival =
+      await fetchSmsticketEvents({
+        filters: {
+          category: 'festival',
+          audience: 'family',
+          page: 0,
+          size: 50
+        }
+      });
+
+    assert.deepEqual(
+      familyFestival.map(
+        (event) =>
+          event.id
+      ),
+      [
+        'sms-family-festival'
+      ]
+    );
+  }
+);
+
+test(
+  'mapped Ticketmaster film event matches the shared film filter',
+  () => {
+    const event =
+      mapTicketmasterEvent(
+        {
+          id:
+            'tm-film',
+
+          name:
+            'Example film screening',
+
+          url:
+            'https://www.ticketmaster.co.uk/example-film/event/1',
+
+          dates: {
+            start: {
+              dateTime:
+                '2099-09-01T19:30:00Z'
+            }
+          },
+
+          classifications: [
+            {
+              segment: {
+                name:
+                  'Arts & Theatre'
+              },
+
+              genre: {
+                name:
+                  'Film'
+              },
+
+              subGenre: {
+                name:
+                  'Cinema'
+              }
+            }
+          ],
+
+          _embedded: {
+            venues: [
+              {
+                name:
+                  'Example Cinema',
+
+                city: {
+                  name:
+                    'London'
+                },
+
+                country: {
+                  countryCode:
+                    'GB'
+                }
+              }
+            ]
+          }
+        },
+        'en'
+      );
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        event,
+        'film'
+      ),
+      true
+    );
+
+    assert.ok(
+      event.taxonomy.domains
+        .includes(
+          'film'
+        )
+    );
+  }
+);
+
+test(
+  'aggregate API and Ticketmaster requests use taxonomy filter v1 integration',
+  () => {
+    const apiSource =
+      readFileSync(
+        new URL(
+          '../src/api/eventsApi.js',
+          import.meta.url
+        ),
+        'utf8'
+      );
+
+    const ticketmasterSource =
+      readFileSync(
+        new URL(
+          '../src/adapters/ticketmaster.js',
+          import.meta.url
+        ),
+        'utf8'
+      );
+
+    assert.match(
+      apiSource,
+      /matchesEventDiscoveryFilters/
+    );
+
+    assert.match(
+      ticketmasterSource,
+      /case\s+'film':[\s\S]*?classificationName:\s*'Film'/
+    );
+
+    assert.match(
+      ticketmasterSource,
+      /classificationName'\s*,\s*'Family'/
+    );
+  }
+);

--- a/tests/event-taxonomy-filters.test.mjs
+++ b/tests/event-taxonomy-filters.test.mjs
@@ -510,3 +510,29 @@ test(
     );
   }
 );
+
+test(
+  'events page preserves taxonomy-filtered results without legacy category refiltering',
+  () => {
+    const entrySource =
+      readFileSync(
+        new URL(
+          '../src/events-entry.js',
+          import.meta.url
+        ),
+        'utf8'
+      );
+
+    assert.equal(
+      entrySource.includes(
+        'out = out.filter(e => e.category === filters.category)'
+      ),
+      false
+    );
+
+    assert.match(
+      entrySource,
+      /Category and audience filtering is already applied by[\s\S]*?shared taxonomy matcher before[\s\S]*?pagination/
+    );
+  }
+);

--- a/tests/events-filter-ux.test.mjs
+++ b/tests/events-filter-ux.test.mjs
@@ -222,6 +222,131 @@ test('summary renders accessible removable chips and clear-all action', () => {
   assert.equal(cleared, 1);
 });
 
+test('family audience is represented as a removable active filter', () => {
+  const descriptors =
+    getActiveFilterDescriptors(
+      {
+        category: 'film',
+        audience: 'family'
+      },
+      {
+        labels: {
+          categories: {
+            film: 'Film a kino'
+          },
+          audiences: {
+            family: 'Pro rodiny'
+          }
+        }
+      }
+    );
+
+  assert.deepEqual(
+    descriptors,
+    [
+      {
+        key: 'category',
+        label: 'Film a kino'
+      },
+      {
+        key: 'audience',
+        label: 'Pro rodiny'
+      }
+    ]
+  );
+});
+
+test('events page exposes film and family filters with URL state', () => {
+  const html =
+    readFileSync(
+      new URL(
+        '../events.html',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+  const entry =
+    readFileSync(
+      new URL(
+        '../src/events-entry.js',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+  const styles =
+    readFileSync(
+      new URL(
+        '../src/styles/partials/_filters-parity-final.scss',
+        import.meta.url
+      ),
+      'utf8'
+    );
+
+  assert.match(
+    html,
+    /<option value="film"[^>]*data-i18n-key="category-film"/
+  );
+
+  assert.match(
+    html,
+    /id="filter-audience-family"[^>]*type="checkbox"[^>]*value="family"/
+  );
+
+  assert.match(
+    entry,
+    /p\.set\('audience', 'family'\)/
+  );
+
+  assert.match(
+    entry,
+    /sp\.get\('audience'\) ===\s*'family'/
+  );
+
+  assert.match(
+    styles,
+    /AJSEE_EVENTS_FAMILY_AUDIENCE_FILTER_V1/
+  );
+
+  for (
+    const locale of [
+      'cs',
+      'en',
+      'de',
+      'sk',
+      'pl',
+      'hu'
+    ]
+  ) {
+    const messages =
+      JSON.parse(
+        readFileSync(
+          new URL(
+            `../src/locales/${locale}.json`,
+            import.meta.url
+          ),
+          'utf8'
+        )
+      );
+
+    assert.equal(
+      typeof messages['category-film'],
+      'string'
+    );
+
+    assert.equal(
+      typeof messages.filters?.film,
+      'string'
+    );
+
+    assert.equal(
+      typeof messages.filters?.family,
+      'string'
+    );
+  }
+});
+
 test('events page preserves the quick-filter toolbar', () => {
   const source = readFileSync(
     new URL('../src/events-entry.js', import.meta.url),

--- a/tests/events-filter-ux.test.mjs
+++ b/tests/events-filter-ux.test.mjs
@@ -291,7 +291,12 @@ test('events page exposes film and family filters with URL state', () => {
 
   assert.match(
     html,
-    /id="filter-audience-family"[^>]*type="checkbox"[^>]*value="family"/
+    /<button(?=[^>]*id="filter-audience-family")(?=[^>]*data-i18n-key="filters\.family")(?=[^>]*aria-pressed="false")[^>]*>/
+  );
+
+  assert.doesNotMatch(
+    html,
+    /<label[^>]*for="filter-audience-family"/
   );
 
   assert.match(
@@ -304,9 +309,19 @@ test('events page exposes film and family filters with URL state', () => {
     /sp\.get\('audience'\) ===\s*'family'/
   );
 
-  assert.match(
+  assert.doesNotMatch(
     styles,
     /AJSEE_EVENTS_FAMILY_AUDIENCE_FILTER_V1/
+  );
+
+  assert.match(
+    entry,
+    /family-audience-click/
+  );
+
+  assert.match(
+    entry,
+    /aria-pressed/
   );
 
   for (


### PR DESCRIPTION
## Summary

Adds the first user-facing filters powered by the AJSEE event taxonomy.

### Runtime

- adds shared taxonomy-aware event filtering
- preserves legacy behaviour for concerts, festivals and theatre
- expands sport using the taxonomy domain
- adds Film and cinema filtering
- adds an independent family audience filter
- integrates SMS Ticket and Ticketmaster

### User interface

- adds Film and cinema to the category selector
- adds a combinable Family-friendly checkbox
- persists the audience filter as `audience=family`
- supports independently removable active-filter chips
- adds translations for CS, EN, DE, SK, PL and HU

## Compatibility

Existing URLs remain supported:

- `?segment=concert`
- `?segment=festival`
- `?segment=theatre`
- `?segment=sport`

New URLs:

- `?segment=film`
- `?audience=family`
- `?segment=theatre&audience=family`

## Validation

- 14/14 focused runtime tests
- 27/27 focused UI and taxonomy tests
- 62/62 complete regression tests
- Vite production build passed
- working tree clean