### PR TITLE
fix(events): include family theatre in theatre filter

### DIFF
--- a/src/taxonomy/event-filtering.js
+++ b/src/taxonomy/event-filtering.js
@@ -115,12 +115,19 @@ export function matchesEventCategoryFilter(
     );
   }
 
+  if (wanted === 'theatre') {
+    return (
+      legacyCategory === 'theatre' ||
+      eventTypes.includes('theatre')
+    );
+  }
+
   /*
-   * Concert, festival and theatre intentionally retain
-   * the existing legacy category semantics in filter v1.
+   * Concert and festival retain their existing legacy
+   * category semantics in filter v1.
    *
-   * Their taxonomy domains currently overlap too broadly
-   * for a safe public filter migration.
+   * Their taxonomy domains and event types currently
+   * overlap too broadly for a safe public migration.
    */
   return (
     legacyCategory ===

--- a/tests/event-taxonomy-filters.test.mjs
+++ b/tests/event-taxonomy-filters.test.mjs
@@ -17,7 +17,7 @@ import {
 } from '../src/adapters/ticketmaster.js';
 
 test(
-  'legacy concert, festival and theatre filters keep exact category semantics',
+  'concert keeps legacy semantics and stage domain alone is not theatre',
   () => {
     const party = {
       category: 'concert',
@@ -51,6 +51,65 @@ test(
       matchesEventCategoryFilter(
         otherShow,
         'theatre'
+      ),
+      false
+    );
+  }
+);
+
+test(
+  'theatre filter includes family theatre by taxonomy event type',
+  () => {
+    const familyTheatre = {
+      category: 'family',
+
+      taxonomy: {
+        domains: [
+          'stage'
+        ],
+
+        eventTypes: [
+          'theatre',
+          'show'
+        ],
+
+        audiences: [
+          'family'
+        ]
+      }
+    };
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        familyTheatre,
+        'theatre'
+      ),
+      true
+    );
+
+    assert.equal(
+      matchesEventAudienceFilter(
+        familyTheatre,
+        'family'
+      ),
+      true
+    );
+
+    assert.equal(
+      matchesEventDiscoveryFilters(
+        familyTheatre,
+        {
+          category: 'theatre',
+          audience: 'family'
+        }
+      ),
+      true
+    );
+
+    assert.equal(
+      matchesEventCategoryFilter(
+        familyTheatre,
+        'concert'
       ),
       false
     );


### PR DESCRIPTION
## Summary

Expands the Theatre filter using the precise taxonomy event type while preserving existing Concert and Festival semantics.

## Changes

- Theatre now matches events when:
  - the legacy category is `theatre`, or
  - taxonomy `eventTypes` contains `theatre`
- The broader `stage` domain alone is intentionally insufficient.
- Concert and Festival filters remain unchanged.
- Added regression coverage for family theatre events.

## Validation

- Current SMS Ticket audit snapshot:
  - Theatre: 377 → 411
  - Theatre + Family: 0 → 30
- Focused tests passed.
- Full test suite passed.
- Vite production build passed.