### PR TITLE
feat(events): add smart empty-state recovery

### DIFF
--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -20,7 +20,9 @@ import {
   detectDatePreset,
   getActiveFilterDescriptors,
   getDatePresetRange,
-  renderEventsFilterSummary
+  renderEventsFilterSummary,
+  getEmptyStateRecommendation,
+  getEmptyStateRecommendationLabel
 } from './events-filter-ux.js';
 
 import { initLangDropdown } from './utils/lang-dropdown.js';
@@ -1230,60 +1232,357 @@ function ensureEventsStateStyles() {
       cursor:pointer;
       box-shadow:0 10px 24px rgba(9,30,66,.12);
     }
+    .ajsee-events-state__actions{
+      display:flex;
+      flex-wrap:wrap;
+      align-items:center;
+      justify-content:center;
+      gap:10px;
+      margin-top:18px;
+    }
+    .ajsee-events-state__secondary{
+      background:#fff !important;
+      color:#0A3D62 !important;
+      box-shadow:none !important;
+    }
+    .ajsee-events-state button:hover{
+      transform:translateY(-1px);
+    }
+    .ajsee-events-state button:focus-visible{
+      outline:3px solid rgba(14,136,240,.32);
+      outline-offset:3px;
+    }
+    .ajsee-events-state button:disabled{
+      cursor:wait;
+      opacity:.65;
+      transform:none;
+    }
+    @media (max-width:520px){
+      .ajsee-events-state__actions{
+        align-items:stretch;
+        flex-direction:column;
+      }
+      .ajsee-events-state__actions button{
+        width:100%;
+      }
+    }
   `);
 }
 
+function formatEventsMessage(
+  template,
+  values = {}
+) {
+  return Object.entries(
+    values
+  ).reduce(
+    (
+      result,
+      [key, value]
+    ) =>
+      result
+        .split(
+          `{${key}}`
+        )
+        .join(
+          String(value)
+        ),
+    String(
+      template ||
+      ''
+    )
+  );
+}
+
+function focusEventsResultsSummary() {
+  const count =
+    qs('#eventsResultsCount');
+
+  if (!count) {
+    return;
+  }
+
+  count.setAttribute(
+    'tabindex',
+    '-1'
+  );
+
+  count.focus({
+    preventScroll:
+      false
+  });
+
+  count.addEventListener(
+    'blur',
+    () => {
+      count.removeAttribute(
+        'tabindex'
+      );
+    },
+    {
+      once:
+        true
+    }
+  );
+}
+
 function renderEventsStateMessage(kind = 'rateLimit') {
-  const list = document.getElementById('eventsList');
-  if (!list) return;
+  const list =
+    document.getElementById(
+      'eventsList'
+    );
+
+  if (!list) {
+    return;
+  }
 
   ensureEventsStateStyles();
 
-  const copy = kind === 'rateLimit'
-    ? getRateLimitCopy()
-    : {
-        title: t('events-empty-title', currentLang === 'en' ? 'No events found' : 'Nenašli jsme žádné akce'),
-        body: t(
-          'events-empty-body',
-          currentLang === 'en'
-            ? 'Remove one of the active filters or clear them all.'
-            : 'Odeberte některý z aktivních filtrů nebo je všechny vymažte.'
-        ),
-        retry: t('events-empty-clear', currentLang === 'en' ? 'Clear filters' : 'Vymazat filtry')
-      };
+  const isRateLimit =
+    kind === 'rateLimit';
 
-  updateResultsCount(kind === 'rateLimit' ? 'dočasně pozastaveno' : 0);
+  const uxLabels =
+    getEventsFilterUxLabels();
 
-  list.innerHTML = `
-    <div class="ajsee-events-state" role="status" aria-live="polite">
-      <div class="ajsee-events-state__eyebrow" aria-hidden="true">${kind === 'rateLimit' ? '⏳' : '🔎'}</div>
-      <h3>${esc(copy.title)}</h3>
-      <p>${esc(copy.body)}</p>
-      <button type="button" data-ajsee-events-retry>${esc(copy.retry)}</button>
-    </div>
-  `;
+  const recommendation =
+    isRateLimit
+      ? null
+      : getEmptyStateRecommendation(
+          currentFilters,
+          {
+            locale:
+              currentLang,
 
-  const retry = list.querySelector('[data-ajsee-events-retry]');
-  if (retry) {
-    retry.addEventListener('click', () => {
-      if (kind === 'rateLimit' && isTicketmasterRateLimited()) {
-        renderEventsStateMessage(kind);
-        return;
-      }
+            labels:
+              uxLabels
+          }
+        );
 
-      if (kind === 'empty') {
-        void resetAllEventFilters();
-        return;
-      }
+  const recommendationLabel =
+    getEmptyStateRecommendationLabel(
+      recommendation
+    );
 
-      _lastFetchSig = '';
-      resetEventsPager();
-      void renderAndSync({ resetPage: true });
-    }, { once: true });
+  const copy =
+    isRateLimit
+      ? getRateLimitCopy()
+      : {
+          title:
+            t(
+              'events-empty-title',
+              currentLang === 'en'
+                ? 'No events found'
+                : 'Nenašli jsme žádné akce'
+            ),
+
+          body:
+            recommendation
+              ? formatEventsMessage(
+                  t(
+                    'events-empty-body',
+                    currentLang === 'en'
+                      ? 'Try removing “{filter}” while keeping the other settings.'
+                      : 'Zkuste odebrat filtr „{filter}“ a ponechat ostatní nastavení.'
+                  ),
+                  {
+                    filter:
+                      recommendationLabel
+                  }
+                )
+              : t(
+                  'events-empty-no-filters',
+                  currentLang === 'en'
+                    ? 'No events are currently available for this selection.'
+                    : 'Pro aktuální výběr zatím nejsou dostupné žádné akce.'
+                ),
+
+          remove:
+            recommendation
+              ? formatEventsMessage(
+                  t(
+                    'events-empty-remove',
+                    currentLang === 'en'
+                      ? 'Remove “{filter}”'
+                      : 'Odebrat „{filter}“'
+                  ),
+                  {
+                    filter:
+                      recommendationLabel
+                  }
+                )
+              : '',
+
+          clear:
+            t(
+              'events-empty-clear',
+              currentLang === 'en'
+                ? 'Clear all filters'
+                : 'Vymazat všechny filtry'
+            )
+        };
+
+  updateResultsCount(
+    isRateLimit
+      ? 'dočasně pozastaveno'
+      : 0
+  );
+
+  if (isRateLimit) {
+    list.innerHTML = `
+      <div
+        class="ajsee-events-state"
+        role="status"
+        aria-live="polite"
+      >
+        <div
+          class="ajsee-events-state__eyebrow"
+          aria-hidden="true"
+        >⏳</div>
+
+        <h3>${esc(copy.title)}</h3>
+        <p>${esc(copy.body)}</p>
+
+        <button
+          type="button"
+          data-ajsee-events-retry
+        >${esc(copy.retry)}</button>
+      </div>
+    `;
+
+    const retry =
+      list.querySelector(
+        '[data-ajsee-events-retry]'
+      );
+
+    if (retry) {
+      retry.addEventListener(
+        'click',
+        () => {
+          if (
+            isTicketmasterRateLimited()
+          ) {
+            renderEventsStateMessage(
+              kind
+            );
+
+            return;
+          }
+
+          _lastFetchSig =
+            '';
+
+          resetEventsPager();
+
+          void renderAndSync({
+            resetPage:
+              true
+          });
+        },
+        {
+          once:
+            true
+        }
+      );
+    }
+  } else {
+    const actions =
+      recommendation
+        ? `
+          <div class="ajsee-events-state__actions">
+            <button
+              type="button"
+              data-ajsee-events-remove-filter
+            >${esc(copy.remove)}</button>
+
+            <button
+              type="button"
+              class="ajsee-events-state__secondary"
+              data-ajsee-events-clear
+            >${esc(copy.clear)}</button>
+          </div>
+        `
+        : '';
+
+    list.innerHTML = `
+      <div
+        class="ajsee-events-state"
+        role="region"
+        aria-labelledby="eventsEmptyStateTitle"
+      >
+        <div
+          class="ajsee-events-state__eyebrow"
+          aria-hidden="true"
+        >🔎</div>
+
+        <h3 id="eventsEmptyStateTitle">
+          ${esc(copy.title)}
+        </h3>
+
+        <p>
+          ${esc(copy.body)}
+        </p>
+
+        ${actions}
+      </div>
+    `;
+
+    const removeButton =
+      list.querySelector(
+        '[data-ajsee-events-remove-filter]'
+      );
+
+    if (
+      removeButton &&
+      recommendation
+    ) {
+      removeButton.addEventListener(
+        'click',
+        async () => {
+          removeButton.disabled =
+            true;
+
+          await clearSingleEventFilter(
+            recommendation.key
+          );
+
+          focusEventsResultsSummary();
+        },
+        {
+          once:
+            true
+        }
+      );
+    }
+
+    const clearButton =
+      list.querySelector(
+        '[data-ajsee-events-clear]'
+      );
+
+    if (clearButton) {
+      clearButton.addEventListener(
+        'click',
+        async () => {
+          clearButton.disabled =
+            true;
+
+          await resetAllEventFilters();
+
+          focusEventsResultsSummary();
+        },
+        {
+          once:
+            true
+        }
+      );
+    }
   }
 
   updateEventsPagerControls();
-  announce(`${copy.title}. ${copy.body}`);
+
+  announce(
+    `${copy.title}. ${copy.body}`
+  );
 }
 
 function bindTicketmasterRateLimitEvents() {

--- a/src/events-filter-ux.js
+++ b/src/events-filter-ux.js
@@ -230,6 +230,111 @@ export function getActiveFilterDescriptors(
   return descriptors;
 }
 
+/*
+ * Smart empty-state recommendation v1.
+ *
+ * The order preserves the user's strongest intent:
+ * location is removed only after narrower discovery filters.
+ * Sort is excluded because it cannot reduce the result count.
+ */
+const EMPTY_STATE_FILTER_PRIORITY =
+  Object.freeze([
+    'keyword',
+    'date',
+    'audience',
+    'category',
+    'place'
+  ]);
+
+export function getEmptyStateRecommendation(
+  filters = {},
+  {
+    locale = 'cs',
+    labels = {},
+    now = new Date(),
+    priority =
+      EMPTY_STATE_FILTER_PRIORITY
+  } = {}
+) {
+  const descriptors =
+    getActiveFilterDescriptors(
+      filters,
+      {
+        locale,
+        labels,
+        now
+      }
+    );
+
+  for (const key of priority) {
+    const descriptor =
+      descriptors.find(
+        (item) =>
+          item.key === key
+      );
+
+    if (descriptor) {
+      return descriptor;
+    }
+  }
+
+  return null;
+}
+
+export function getEmptyStateRecommendationLabel(
+  recommendation = null
+) {
+  const label =
+    String(
+      recommendation?.label ||
+      ''
+    ).trim();
+
+  if (
+    !label ||
+    recommendation?.key !== 'keyword'
+  ) {
+    return label;
+  }
+
+  const quotePairs = [
+    ['“', '”'],
+    ['„', '“'],
+    ['„', '”'],
+    ['"', '"'],
+    ['«', '»']
+  ];
+
+  for (
+    const [
+      openingQuote,
+      closingQuote
+    ] of quotePairs
+  ) {
+    if (
+      label.startsWith(
+        openingQuote
+      ) &&
+      label.endsWith(
+        closingQuote
+      ) &&
+      label.length >
+        openingQuote.length +
+        closingQuote.length
+    ) {
+      return label
+        .slice(
+          openingQuote.length,
+          label.length -
+            closingQuote.length
+        )
+        .trim();
+    }
+  }
+
+  return label;
+}
+
 export function renderEventsFilterSummary({
   document,
   host,

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -437,7 +437,9 @@
   "events-clear-filters": "Vymazat vše",
   "events-remove-filter": "Odebrat filtr",
   "events-empty-title": "Nenašli jsme žádné akce",
-  "events-empty-body": "Odeberte některý z aktivních filtrů nebo je všechny vymažte.",
+  "events-empty-body": "Zkuste odebrat filtr „{filter}“ a ponechat ostatní nastavení.",
   "events-empty-clear": "Vymazat filtry",
+  "events-empty-remove": "Odebrat „{filter}“",
+  "events-empty-no-filters": "Pro aktuální výběr zatím nejsou dostupné žádné akce.",
   "category-film": "Film a kino"
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -437,7 +437,9 @@
   "events-clear-filters": "Alle löschen",
   "events-remove-filter": "Filter entfernen",
   "events-empty-title": "Keine Veranstaltungen gefunden",
-  "events-empty-body": "Entfernen Sie einen aktiven Filter oder löschen Sie alle Filter.",
+  "events-empty-body": "Entfernen Sie zunächst den Filter „{filter}“ und behalten Sie die übrigen Einstellungen bei.",
   "events-empty-clear": "Filter löschen",
+  "events-empty-remove": "„{filter}“ entfernen",
+  "events-empty-no-filters": "Für diese Auswahl sind derzeit keine Veranstaltungen verfügbar.",
   "category-film": "Film & Kino"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -437,7 +437,9 @@
   "events-clear-filters": "Clear all",
   "events-remove-filter": "Remove filter",
   "events-empty-title": "No events found",
-  "events-empty-body": "Remove one of the active filters or clear them all.",
+  "events-empty-body": "Try removing “{filter}” while keeping the other settings.",
   "events-empty-clear": "Clear filters",
+  "events-empty-remove": "Remove “{filter}”",
+  "events-empty-no-filters": "No events are currently available for this selection.",
   "category-film": "Film & cinema"
 }

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -437,7 +437,9 @@
   "events-clear-filters": "Összes törlése",
   "events-remove-filter": "Szűrő eltávolítása",
   "events-empty-title": "Nem találtunk eseményeket",
-  "events-empty-body": "Távolítson el egy aktív szűrőt, vagy törölje az összeset.",
+  "events-empty-body": "Próbálja meg eltávolítani a(z) „{filter}” szűrőt, a többi beállítás megtartásával.",
   "events-empty-clear": "Szűrők törlése",
+  "events-empty-remove": "„{filter}” eltávolítása",
+  "events-empty-no-filters": "Ehhez a választáshoz jelenleg nem érhetők el események.",
   "category-film": "Film és mozi"
 }

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -437,7 +437,9 @@
   "events-clear-filters": "Wyczyść wszystko",
   "events-remove-filter": "Usuń filtr",
   "events-empty-title": "Nie znaleziono wydarzeń",
-  "events-empty-body": "Usuń jeden z aktywnych filtrów albo wyczyść je wszystkie.",
+  "events-empty-body": "Spróbuj usunąć filtr „{filter}”, zachowując pozostałe ustawienia.",
   "events-empty-clear": "Wyczyść filtry",
+  "events-empty-remove": "Usuń „{filter}”",
+  "events-empty-no-filters": "Dla tego wyboru nie ma obecnie dostępnych wydarzeń.",
   "category-film": "Film i kino"
 }

--- a/src/locales/sk.json
+++ b/src/locales/sk.json
@@ -437,7 +437,9 @@
   "events-clear-filters": "Vymazať všetko",
   "events-remove-filter": "Odstrániť filter",
   "events-empty-title": "Nenašli sme žiadne podujatia",
-  "events-empty-body": "Odstráňte niektorý z aktívnych filtrov alebo ich všetky vymažte.",
+  "events-empty-body": "Skúste odstrániť filter „{filter}“ a ponechať ostatné nastavenia.",
   "events-empty-clear": "Vymazať filtre",
+  "events-empty-remove": "Odstrániť „{filter}“",
+  "events-empty-no-filters": "Pre aktuálny výber momentálne nie sú dostupné žiadne podujatia.",
   "category-film": "Film a kino"
 }

--- a/tests/events-filter-ux.test.mjs
+++ b/tests/events-filter-ux.test.mjs
@@ -1,13 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import {
+  readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 
 import {
   detectDatePreset,
   getActiveFilterDescriptors,
   getDatePresetRange,
-  renderEventsFilterSummary
+  renderEventsFilterSummary,
+  getEmptyStateRecommendation,
+  getEmptyStateRecommendationLabel
 } from '../src/events-filter-ux.js';
 
 test('tomorrow preset uses the next local calendar day', () => {
@@ -497,3 +500,280 @@ test('mobile quick filters expose all actions and bind near-me', () => {
     /#chipNearMe\s*\{[\s\S]*?display:\s*inline-flex\s*!important;/
   );
 });
+
+
+/* AJSEE_SMART_EMPTY_STATE_V1_TESTS */
+test(
+  'smart empty-state recommendation removes narrow filters before location',
+  () => {
+    const recommendation =
+      getEmptyStateRecommendation(
+        {
+          category:
+            'theatre',
+
+          audience:
+            'family',
+
+          city:
+            'Praha',
+
+          cityLabel:
+            'Praha',
+
+          dateFrom:
+            '2026-08-02',
+
+          dateTo:
+            '2026-08-02',
+
+          keyword:
+            'loutky',
+
+          sort:
+            'latest'
+        },
+        {
+          locale:
+            'cs',
+
+          labels: {
+            categories: {
+              theatre:
+                'Divadlo'
+            },
+
+            audiences: {
+              family:
+                'Pro rodiny'
+            }
+          }
+        }
+      );
+
+    assert.deepEqual(
+      recommendation,
+      {
+        key:
+          'keyword',
+
+        label:
+          '“loutky”'
+      }
+    );
+  }
+);
+
+test(
+  'smart empty-state recommendation preserves place until other restrictions are removed',
+  () => {
+    const recommendation =
+      getEmptyStateRecommendation(
+        {
+          category:
+            'film',
+
+          city:
+            'Brno',
+
+          cityLabel:
+            'Brno'
+        },
+        {
+          labels: {
+            categories: {
+              film:
+                'Film a kino'
+            }
+          }
+        }
+      );
+
+    assert.deepEqual(
+      recommendation,
+      {
+        key:
+          'category',
+
+        label:
+          'Film a kino'
+      }
+    );
+  }
+);
+
+test(
+  'sort alone does not create a smart empty-state recommendation',
+  () => {
+    const recommendation =
+      getEmptyStateRecommendation({
+        category:
+          'all',
+
+        sort:
+          'latest'
+      });
+
+    assert.equal(
+      recommendation,
+      null
+    );
+  }
+);
+
+test(
+  'events page exposes targeted empty-state recovery in every locale',
+  () => {
+    const entry =
+      readFileSync(
+        new URL(
+          '../src/events-entry.js',
+          import.meta.url
+        ),
+        'utf8'
+      );
+
+    assert.match(
+      entry,
+      /data-ajsee-events-remove-filter/
+    );
+
+    assert.match(
+      entry,
+      /data-ajsee-events-clear/
+    );
+
+    assert.match(
+      entry,
+      /focusEventsResultsSummary/
+    );
+
+    for (
+      const locale of [
+        'cs',
+        'en',
+        'de',
+        'sk',
+        'pl',
+        'hu'
+      ]
+    ) {
+      const source =
+        readFileSync(
+          new URL(
+            `../src/locales/${locale}.json`,
+            import.meta.url
+          ),
+          'utf8'
+        );
+
+      assert.match(
+        source,
+        /"events-empty-remove"/
+      );
+
+      assert.match(
+        source,
+        /"events-empty-no-filters"/
+      );
+    }
+  }
+);
+
+
+/* AJSEE_EMPTY_STATE_SINGLE_QUOTES_REGRESSION */
+test(
+  'empty-state keyword label has exactly one translated pair of quotes',
+  () => {
+    const keyword =
+      'ajsee-no-results-987654';
+
+    const label =
+      getEmptyStateRecommendationLabel({
+        key:
+          'keyword',
+
+        label:
+          `“${keyword}”`
+      });
+
+    assert.equal(
+      label,
+      keyword
+    );
+
+    assert.equal(
+      getEmptyStateRecommendationLabel({
+        key:
+          'category',
+
+        label:
+          'Divadlo'
+      }),
+      'Divadlo'
+    );
+
+    for (
+      const locale of [
+        'cs',
+        'en',
+        'de',
+        'sk',
+        'pl',
+        'hu'
+      ]
+    ) {
+      const json =
+        JSON.parse(
+          readFileSync(
+            new URL(
+              `../src/locales/${locale}.json`,
+              import.meta.url
+            ),
+            'utf8'
+          )
+        );
+
+      for (
+        const key of [
+          'events-empty-body',
+          'events-empty-remove'
+        ]
+      ) {
+        const template =
+          json[key];
+
+        assert.equal(
+          (
+            template.match(
+              /\{filter\}/g
+            ) ||
+            []
+          ).length,
+          1
+        );
+
+        const rendered =
+          template.replace(
+            '{filter}',
+            label
+          );
+
+        assert.equal(
+          (
+            rendered.match(
+              /ajsee-no-results-987654/g
+            ) ||
+            []
+          ).length,
+          1
+        );
+
+        assert.doesNotMatch(
+          rendered,
+          /[„“”"«»]{2,}/
+        );
+      }
+    }
+  }
+);


### PR DESCRIPTION
## Summary

Improves the zero-results experience on the events page by recommending one specific filter to remove instead of immediately clearing the entire search.

## UX behaviour

When active filters return no events, the empty state:

- recommends removing one concrete restrictive filter,
- keeps all other filters and URL state,
- offers a secondary action to clear all filters,
- moves keyboard focus to the updated results summary after recovery.

## Recommendation priority

The recovery order preserves the strongest parts of the user's intent:

1. Keyword
2. Date
3. Family audience
4. Category
5. Place

Sorting is intentionally excluded because it cannot reduce the number of results.

## Accessibility

- Buttons use native button semantics.
- The empty state is labelled as a region.
- Results remain announced through the existing live region.
- Focus moves to the updated results count after an action.
- Visible focus styles and disabled loading states are included.
- Mobile actions expand to full width.

## Localisation

Added and validated copy for:

- Czech
- English
- German
- Slovak
- Polish
- Hungarian

## Validation

- 26 focused tests passed.
- 68 complete tests passed.
- Vite production build passed.
- All locale JSON files are valid.
- Git diff and changed source files contain no Unicode replacement characters.
- Working tree is clean.