### PR TITLE
feat(events): track empty-state recovery

### DIFF
--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -22,7 +22,8 @@ import {
   getDatePresetRange,
   renderEventsFilterSummary,
   getEmptyStateRecommendation,
-  getEmptyStateRecommendationLabel
+  getEmptyStateRecommendationLabel,
+  getEventsEmptyStateAnalyticsContext
 } from './events-filter-ux.js';
 
 import { initLangDropdown } from './utils/lang-dropdown.js';
@@ -1326,6 +1327,168 @@ function focusEventsResultsSummary() {
   );
 }
 
+let _lastEventsEmptyStateViewSignature =
+  '';
+
+function makeEventsEmptyStateViewSignature(
+  recommendation = null
+) {
+  /*
+   * Raw values are used only in this in-memory signature
+   * to distinguish changed states. They are never included
+   * in the analytics payload.
+   */
+  return JSON.stringify({
+    language:
+      currentLang,
+
+    recommendedFilter:
+      recommendation?.key ||
+      'none',
+
+    category:
+      currentFilters.category ||
+      'all',
+
+    audience:
+      currentFilters.audience ||
+      '',
+
+    placeType:
+      currentFilters.placeType ||
+      '',
+
+    city:
+      currentFilters.city ||
+      '',
+
+    cityLabel:
+      currentFilters.cityLabel ||
+      '',
+
+    cityCountryCode:
+      currentFilters.cityCountryCode ||
+      '',
+
+    dateFrom:
+      currentFilters.dateFrom ||
+      '',
+
+    dateTo:
+      currentFilters.dateTo ||
+      '',
+
+    keyword:
+      currentFilters.keyword ||
+      '',
+
+    nearMeLat:
+      currentFilters.nearMeLat ??
+      null,
+
+    nearMeLon:
+      currentFilters.nearMeLon ??
+      null,
+
+    nearMeRadiusKm:
+      currentFilters.nearMeRadiusKm ??
+      null
+  });
+}
+
+function pushEventsEmptyStateAnalytics(
+  eventName,
+  recommendation,
+  labels
+) {
+  const context =
+    getEventsEmptyStateAnalyticsContext(
+      currentFilters,
+      recommendation,
+      {
+        locale:
+          currentLang,
+
+        labels
+      }
+    );
+
+  const payload = {
+    event:
+      eventName,
+
+    source:
+      'events_empty_state',
+
+    /*
+     * Path deliberately excludes query parameters because
+     * they may contain a keyword or place entered by a user.
+     */
+    page_path:
+      window.location.pathname,
+
+    ...context
+  };
+
+  try {
+    window.dataLayer =
+      window.dataLayer ||
+      [];
+
+    window.dataLayer.push(
+      payload
+    );
+  } catch {
+    /* noop */
+  }
+
+  try {
+    window.__ajsee =
+      window.__ajsee ||
+      {};
+
+    window.__ajsee.lastEventsEmptyStateEvent =
+      payload;
+  } catch {
+    /* noop */
+  }
+
+  return payload;
+}
+
+function trackEventsEmptyStateView(
+  recommendation,
+  labels
+) {
+  const signature =
+    makeEventsEmptyStateViewSignature(
+      recommendation
+    );
+
+  if (
+    signature ===
+    _lastEventsEmptyStateViewSignature
+  ) {
+    return false;
+  }
+
+  _lastEventsEmptyStateViewSignature =
+    signature;
+
+  pushEventsEmptyStateAnalytics(
+    'events_empty_state_view',
+    recommendation,
+    labels
+  );
+
+  return true;
+}
+
+function resetEventsEmptyStateViewTracking() {
+  _lastEventsEmptyStateViewSignature =
+    '';
+}
+
 function renderEventsStateMessage(kind = 'rateLimit') {
   const list =
     document.getElementById(
@@ -1362,6 +1525,15 @@ function renderEventsStateMessage(kind = 'rateLimit') {
     getEmptyStateRecommendationLabel(
       recommendation
     );
+
+  if (isRateLimit) {
+    resetEventsEmptyStateViewTracking();
+  } else {
+    trackEventsEmptyStateView(
+      recommendation,
+      uxLabels
+    );
+  }
 
   const copy =
     isRateLimit
@@ -1538,6 +1710,12 @@ function renderEventsStateMessage(kind = 'rateLimit') {
       removeButton.addEventListener(
         'click',
         async () => {
+          pushEventsEmptyStateAnalytics(
+            'events_empty_state_remove_filter',
+            recommendation,
+            uxLabels
+          );
+
           removeButton.disabled =
             true;
 
@@ -1563,6 +1741,12 @@ function renderEventsStateMessage(kind = 'rateLimit') {
       clearButton.addEventListener(
         'click',
         async () => {
+          pushEventsEmptyStateAnalytics(
+            'events_empty_state_clear_all',
+            recommendation,
+            uxLabels
+          );
+
           clearButton.disabled =
             true;
 
@@ -4330,6 +4514,13 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
       else renderEventsStateMessage('empty');
       return;
     }
+
+    /*
+     * A successful result state ends the current empty-state
+     * impression. Returning to the same zero-result filters
+     * later may therefore create a new legitimate view.
+     */
+    resetEventsEmptyStateViewTracking();
 
     injectProviderBadgeStyles();
 

--- a/src/events-filter-ux.js
+++ b/src/events-filter-ux.js
@@ -335,6 +335,121 @@ export function getEmptyStateRecommendationLabel(
   return label;
 }
 
+/*
+ * Privacy-safe context for empty-state analytics.
+ *
+ * Raw keyword, city, coordinates and full URLs are
+ * intentionally excluded from the returned payload.
+ * Sort is not counted as a restrictive filter.
+ */
+export function getEventsEmptyStateAnalyticsContext(
+  filters = {},
+  recommendation = null,
+  {
+    locale = 'cs',
+    labels = {},
+    now = new Date()
+  } = {}
+) {
+  const descriptors =
+    getActiveFilterDescriptors(
+      filters,
+      {
+        locale,
+        labels,
+        now
+      }
+    );
+
+  const activeKeys =
+    new Set(
+      descriptors.map(
+        (descriptor) =>
+          descriptor.key
+      )
+    );
+
+  const restrictiveFilterCount =
+    descriptors.filter(
+      (descriptor) =>
+        descriptor.key !== 'sort'
+    ).length;
+
+  const category =
+    String(
+      filters.category ||
+      'all'
+    )
+      .trim()
+      .toLowerCase();
+
+  const audience =
+    String(
+      filters.audience ||
+      ''
+    )
+      .trim()
+      .toLowerCase();
+
+  const language =
+    String(
+      locale ||
+      'cs'
+    )
+      .trim()
+      .toLowerCase()
+      .slice(
+        0,
+        2
+      ) ||
+    'cs';
+
+  return Object.freeze({
+    recommended_filter:
+      String(
+        recommendation?.key ||
+        'none'
+      ),
+
+    active_filter_count:
+      restrictiveFilterCount,
+
+    filter_category:
+      category &&
+      category !== 'all'
+        ? category
+        : 'all',
+
+    filter_audience:
+      audience === 'family'
+        ? 'family'
+        : 'all',
+
+    has_place_filter:
+      activeKeys.has(
+        'place'
+      )
+        ? 1
+        : 0,
+
+    has_date_filter:
+      activeKeys.has(
+        'date'
+      )
+        ? 1
+        : 0,
+
+    has_keyword_filter:
+      activeKeys.has(
+        'keyword'
+      )
+        ? 1
+        : 0,
+
+    language
+  });
+}
+
 export function renderEventsFilterSummary({
   document,
   host,

--- a/tests/events-filter-ux.test.mjs
+++ b/tests/events-filter-ux.test.mjs
@@ -10,7 +10,8 @@ import {
   getDatePresetRange,
   renderEventsFilterSummary,
   getEmptyStateRecommendation,
-  getEmptyStateRecommendationLabel
+  getEmptyStateRecommendationLabel,
+  getEventsEmptyStateAnalyticsContext
 } from '../src/events-filter-ux.js';
 
 test('tomorrow preset uses the next local calendar day', () => {
@@ -775,5 +776,217 @@ test(
         );
       }
     }
+  }
+);
+
+
+/* AJSEE_EVENTS_EMPTY_STATE_ANALYTICS_V1 */
+test(
+  'empty-state analytics context contains only privacy-safe filter metadata',
+  () => {
+    const context =
+      getEventsEmptyStateAnalyticsContext(
+        {
+          category:
+            'theatre',
+
+          audience:
+            'family',
+
+          city:
+            'Praha',
+
+          cityLabel:
+            'Praha',
+
+          cityCountryCode:
+            'CZ',
+
+          dateFrom:
+            '2026-08-02',
+
+          dateTo:
+            '2026-08-02',
+
+          keyword:
+            'tajne-hledani-987654',
+
+          sort:
+            'latest'
+        },
+        {
+          key:
+            'keyword',
+
+          label:
+            '“tajne-hledani-987654”'
+        },
+        {
+          locale:
+            'cs',
+
+          labels: {
+            categories: {
+              theatre:
+                'Divadlo'
+            },
+
+            audiences: {
+              family:
+                'Pro rodiny'
+            },
+
+            sorts: {
+              latest:
+                'Nejnovější'
+            }
+          },
+
+          now:
+            new Date(
+              2026,
+              7,
+              2,
+              12,
+              0,
+              0
+            )
+        }
+      );
+
+    assert.deepEqual(
+      context,
+      {
+        recommended_filter:
+          'keyword',
+
+        active_filter_count:
+          5,
+
+        filter_category:
+          'theatre',
+
+        filter_audience:
+          'family',
+
+        has_place_filter:
+          1,
+
+        has_date_filter:
+          1,
+
+        has_keyword_filter:
+          1,
+
+        language:
+          'cs'
+      }
+    );
+
+    const serialized =
+      JSON.stringify(
+        context
+      );
+
+    assert.doesNotMatch(
+      serialized,
+      /Praha/
+    );
+
+    assert.doesNotMatch(
+      serialized,
+      /tajne-hledani/
+    );
+
+    assert.equal(
+      Object.hasOwn(
+        context,
+        'city'
+      ),
+      false
+    );
+
+    assert.equal(
+      Object.hasOwn(
+        context,
+        'keyword'
+      ),
+      false
+    );
+
+    assert.equal(
+      Object.hasOwn(
+        context,
+        'nearMeLat'
+      ),
+      false
+    );
+
+    assert.equal(
+      Object.hasOwn(
+        context,
+        'page_location'
+      ),
+      false
+    );
+  }
+);
+
+test(
+  'events empty-state analytics use dataLayer events and deduplicate unchanged views',
+  () => {
+    const entry =
+      readFileSync(
+        new URL(
+          '../src/events-entry.js',
+          import.meta.url
+        ),
+        'utf8'
+      );
+
+    for (
+      const eventName of [
+        'events_empty_state_view',
+        'events_empty_state_remove_filter',
+        'events_empty_state_clear_all'
+      ]
+    ) {
+      assert.match(
+        entry,
+        new RegExp(
+          eventName
+        )
+      );
+    }
+
+    assert.match(
+      entry,
+      /window\.dataLayer\.push\(\s*payload\s*\)/
+    );
+
+    assert.match(
+      entry,
+      /_lastEventsEmptyStateViewSignature/
+    );
+
+    assert.match(
+      entry,
+      /signature\s*===\s*_lastEventsEmptyStateViewSignature/
+    );
+
+    assert.match(
+      entry,
+      /page_path:\s*window\.location\.pathname/
+    );
+
+    assert.match(
+      entry,
+      /lastEventsEmptyStateEvent/
+    );
+
+    assert.match(
+      entry,
+      /resetEventsEmptyStateViewTracking\(\);[\s\S]*?injectProviderBadgeStyles/
+    );
   }
 );


### PR DESCRIPTION
## Summary

Adds privacy-safe analytics for the smart empty state on the events page.

## Events

- `events_empty_state_view`
- `events_empty_state_remove_filter`
- `events_empty_state_clear_all`

## Behaviour

- An unchanged zero-results state records only one view event.
- Removing the recommended filter records a dedicated recovery event.
- Clearing all filters records a dedicated recovery event.
- Returning to a zero-results state after successful results can create a new legitimate view.

## Privacy

The payload intentionally excludes:

- raw search keywords,
- city names and labels,
- coordinates,
- full page URLs and query parameters.

Only structured metadata is sent:

- recommended filter type,
- number of restrictive filters,
- category,
- audience,
- presence of place, date and keyword filters,
- language,
- pathname without query parameters.

## Validation

- 20 focused tests passed.
- 71 complete tests passed.
- Vite production build passed.
- Working tree is clean.