### PR TITLE
fix(reviews): make publication workflow atomic

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,11 @@
     "reviews:build": "node scripts/build-reviews.mjs",
     "review-details:build": "node scripts/build-review-details.mjs",
     "review-details:localize": "cross-env REVIEW_LOCALIZE=1 node scripts/build-review-details.mjs",
-    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs tests/event-modal-ticket-options-dom.test.mjs tests/events-filter-ux.test.mjs tests/event-taxonomy.test.mjs tests/event-taxonomy-runtime.test.mjs tests/event-taxonomy-filters.test.mjs",
+    "reviews:test": "node --test --test-concurrency=1 tests/reviews.test.mjs tests/event-categories.test.mjs tests/smsticket-availability.test.mjs tests/smsticket-ticket-options.test.mjs tests/event-modal-ticket-options-dom.test.mjs tests/events-filter-ux.test.mjs tests/event-taxonomy.test.mjs tests/event-taxonomy-runtime.test.mjs tests/event-taxonomy-filters.test.mjs tests/review-publication-workflow.test.mjs",
     "events:modal:test": "node --test --test-concurrency=1 tests/event-modal-ticket-options-dom.test.mjs",
-    "events:filters:test": "node --test --test-concurrency=1 tests/events-filter-ux.test.mjs"
+    "events:filters:test": "node --test --test-concurrency=1 tests/events-filter-ux.test.mjs",
+    "reviews:publish": "node scripts/set-review-publication.mjs publish",
+    "reviews:unpublish": "node scripts/set-review-publication.mjs unpublish"
   },
   "devDependencies": {
     "@squoosh/cli": "^0.7.1",

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -150,6 +150,8 @@ collections:
     description: "Edit review content here. Publishing and unpublishing are handled only through the validated AJSEE publication commands."
     folder: "content/reviews/items"
     create: true
+    publish: false
+    delete: false
     format: json
     identifier_field: "showTitle"
     slug: "{{fields.slug}}"

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -147,6 +147,7 @@ collections:
   - name: "reviews"
     label: "Reviews"
     label_singular: "Review"
+    description: "Edit review content here. Publishing and unpublishing are handled only through the validated AJSEE publication commands."
     folder: "content/reviews/items"
     create: true
     format: json
@@ -163,24 +164,15 @@ collections:
         hint: "Example: jesus-christ-superstar-london-2026. Use lowercase letters, numbers and hyphens only."
         pattern: ['^[a-z0-9-]+$', 'Use lowercase letters, numbers and hyphens only.']
 
-      - label: "Workflow status"
+      - label: "Workflow status — managed automatically"
         name: "status"
-        widget: "select"
-        options:
-          - { label: "Draft", value: "draft" }
-          - { label: "Ready for review", value: "ready_for_review" }
-          - { label: "Needs changes", value: "needs_changes" }
-          - { label: "Approved", value: "approved" }
-          - { label: "Published", value: "published" }
-          - { label: "Archived", value: "archived" }
+        widget: "hidden"
         default: "draft"
-        hint: "Use Ready for review when the English version is finished and ready for Adam."
 
-      - label: "Published on website"
+      - label: "Published on website — managed automatically"
         name: "published"
-        widget: "boolean"
+        widget: "hidden"
         default: false
-        hint: "Keep this OFF until Adam approves the review and all language versions are ready."
 
       - label: "Featured review"
         name: "featured"
@@ -238,13 +230,10 @@ collections:
         picker_utc: true
         format: "YYYY-MM-DDTHH:mm:ss[Z]"
 
-      - label: "Published date"
+      - label: "Published date — managed automatically"
         name: "publishedAt"
-        widget: "datetime"
-        required: false
-        picker_utc: true
-        format: "YYYY-MM-DDTHH:mm:ss[Z]"
-        hint: "Fill this only when the review is ready to be published."
+        widget: "hidden"
+        default: ""
 
       - label: "Author name"
         name: "author"

--- a/scripts/review-publication-state.mjs
+++ b/scripts/review-publication-state.mjs
@@ -1,0 +1,150 @@
+const ALLOWED_PUBLICATION_ACTIONS = new Set([
+  'publish',
+  'unpublish'
+]);
+
+const PUBLISHABLE_STATUSES = new Set([
+  'approved',
+  'published'
+]);
+
+function cloneReview(review) {
+  return JSON.parse(
+    JSON.stringify(review)
+  );
+}
+
+function isValidIsoDate(value) {
+  return (
+    typeof value === 'string' &&
+    value.trim() !== '' &&
+    Number.isFinite(Date.parse(value))
+  );
+}
+
+function assertReviewObject(review) {
+  if (
+    !review ||
+    typeof review !== 'object' ||
+    Array.isArray(review)
+  ) {
+    throw new Error(
+      'Review must be a JSON object.'
+    );
+  }
+
+  if (
+    typeof review.slug !== 'string' ||
+    review.slug.trim() === ''
+  ) {
+    throw new Error(
+      'Review must contain a valid slug.'
+    );
+  }
+
+  if (typeof review.status !== 'string') {
+    throw new Error(
+      'Review must contain a string status.'
+    );
+  }
+
+  if (typeof review.published !== 'boolean') {
+    throw new Error(
+      'Review must contain a boolean published value.'
+    );
+  }
+
+  if (typeof review.publishedAt !== 'string') {
+    throw new Error(
+      'Review must contain a string publishedAt value.'
+    );
+  }
+}
+
+export function assertReviewPublicationInvariant(review) {
+  assertReviewObject(review);
+
+  if (review.published === true) {
+    if (review.status !== 'published') {
+      throw new Error(
+        `Published review ${review.slug} must have status "published".`
+      );
+    }
+
+    if (!isValidIsoDate(review.publishedAt)) {
+      throw new Error(
+        `Published review ${review.slug} must have a valid publishedAt value.`
+      );
+    }
+
+    return true;
+  }
+
+  if (review.status === 'published') {
+    throw new Error(
+      `Unpublished review ${review.slug} cannot have status "published".`
+    );
+  }
+
+  if (review.publishedAt !== '') {
+    throw new Error(
+      `Unpublished review ${review.slug} must have an empty publishedAt value.`
+    );
+  }
+
+  return true;
+}
+
+export function transitionReviewPublication(
+  review,
+  action,
+  nowIso = new Date().toISOString()
+) {
+  assertReviewObject(review);
+
+  if (!ALLOWED_PUBLICATION_ACTIONS.has(action)) {
+    throw new Error(
+      `Unsupported publication action: ${action}`
+    );
+  }
+
+  if (!PUBLISHABLE_STATUSES.has(review.status)) {
+    throw new Error(
+      `Review ${review.slug} cannot be ${action}ed from status "${review.status}".`
+    );
+  }
+
+  const nextReview = cloneReview(review);
+
+  if (action === 'publish') {
+    if (
+      review.status === 'published' &&
+      review.published === true &&
+      isValidIsoDate(review.publishedAt)
+    ) {
+      assertReviewPublicationInvariant(nextReview);
+      return nextReview;
+    }
+
+    if (!isValidIsoDate(nowIso)) {
+      throw new Error(
+        'Publish action requires a valid ISO timestamp.'
+      );
+    }
+
+    nextReview.status = 'published';
+    nextReview.published = true;
+    nextReview.publishedAt =
+      new Date(nowIso).toISOString();
+  }
+
+  if (action === 'unpublish') {
+    nextReview.status = 'approved';
+    nextReview.published = false;
+    nextReview.publishedAt = '';
+  }
+
+  assertReviewPublicationInvariant(nextReview);
+
+  return nextReview;
+}

--- a/scripts/set-review-publication.mjs
+++ b/scripts/set-review-publication.mjs
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+import {
+  transitionReviewPublication
+} from './review-publication-state.mjs';
+
+const root = process.cwd();
+
+const action = process.argv[2];
+const slug = process.argv[3];
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function validateSlug(value) {
+  return (
+    typeof value === 'string' &&
+    /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value)
+  );
+}
+
+function runReviewTests() {
+  const npmExecPath =
+    process.env.npm_execpath;
+
+  let command;
+  let args;
+  let useShell = false;
+
+  if (npmExecPath) {
+    command = process.execPath;
+    args = [
+      npmExecPath,
+      'run',
+      'reviews:test'
+    ];
+  }
+  else {
+    command =
+      process.platform === 'win32'
+        ? 'npm.cmd'
+        : 'npm';
+
+    args = [
+      'run',
+      'reviews:test'
+    ];
+
+    useShell =
+      process.platform === 'win32';
+  }
+
+  return spawnSync(
+    command,
+    args,
+    {
+      cwd: root,
+      env: process.env,
+      stdio: 'inherit',
+      shell: useShell
+    }
+  );
+}
+
+if (
+  action !== 'publish' &&
+  action !== 'unpublish'
+) {
+  fail(
+    'Usage: node scripts/set-review-publication.mjs <publish|unpublish> <review-slug>'
+  );
+}
+
+if (!validateSlug(slug)) {
+  fail(
+    'Review slug is missing or invalid.'
+  );
+}
+
+const reviewPath = path.join(
+  root,
+  'content',
+  'reviews',
+  'items',
+  `${slug}.json`
+);
+
+if (!fs.existsSync(reviewPath)) {
+  fail(
+    `Review not found: ${reviewPath}`
+  );
+}
+
+const originalSource =
+  fs.readFileSync(
+    reviewPath,
+    'utf8'
+  );
+
+let currentReview;
+
+try {
+  currentReview =
+    JSON.parse(originalSource);
+}
+catch (error) {
+  fail(
+    `Review JSON is invalid: ${error.message}`
+  );
+}
+
+if (currentReview.slug !== slug) {
+  fail(
+    `File slug "${slug}" does not match review slug "${currentReview.slug}".`
+  );
+}
+
+let nextReview;
+
+try {
+  nextReview =
+    transitionReviewPublication(
+      currentReview,
+      action,
+      new Date().toISOString()
+    );
+}
+catch (error) {
+  fail(error.message);
+}
+
+const lineEnding =
+  originalSource.includes('\r\n')
+    ? '\r\n'
+    : '\n';
+
+const nextSource =
+  JSON.stringify(
+    nextReview,
+    null,
+    2
+  ).replace(/\n/g, lineEnding) +
+  lineEnding;
+
+if (nextSource === originalSource) {
+  console.log(
+    `Review "${slug}" already has the requested publication state.`
+  );
+
+  process.exit(0);
+}
+
+console.log('');
+console.log('Publication state before change:');
+console.log({
+  status: currentReview.status,
+  published: currentReview.published,
+  publishedAt: currentReview.publishedAt
+});
+
+console.log('');
+console.log('Publication state after change:');
+console.log({
+  status: nextReview.status,
+  published: nextReview.published,
+  publishedAt: nextReview.publishedAt
+});
+
+fs.writeFileSync(
+  reviewPath,
+  nextSource,
+  'utf8'
+);
+
+console.log('');
+console.log('Running AJSEE safety tests...');
+
+const testResult =
+  runReviewTests();
+
+if (
+  testResult.error ||
+  testResult.status !== 0
+) {
+  fs.writeFileSync(
+    reviewPath,
+    originalSource,
+    'utf8'
+  );
+
+  console.error('');
+  console.error(
+    'Safety tests failed. The original review file was restored.'
+  );
+
+  if (testResult.error) {
+    console.error(
+      testResult.error.message
+    );
+  }
+
+  process.exit(1);
+}
+
+console.log('');
+console.log(
+  `Review "${slug}" was ${action === 'publish' ? 'published' : 'unpublished'} successfully.`
+);
+
+console.log(
+  'The file is changed locally. Review the Git diff before committing.'
+);

--- a/tests/review-publication-workflow.test.mjs
+++ b/tests/review-publication-workflow.test.mjs
@@ -187,6 +187,16 @@ test(
       /name:\s*"publishedAt"\s*\r?\n\s+widget:\s*"hidden"/
     );
 
+    assert.match(
+      reviewsCollection,
+      /publish:\s*false/
+    );
+
+    assert.match(
+      reviewsCollection,
+      /delete:\s*false/
+    );
+
     assert.doesNotMatch(
       reviewsCollection,
       /label:\s*"Published",\s*value:\s*"published"/

--- a/tests/review-publication-workflow.test.mjs
+++ b/tests/review-publication-workflow.test.mjs
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  assertReviewPublicationInvariant,
+  transitionReviewPublication
+} from '../scripts/review-publication-state.mjs';
+
+const root = process.cwd();
+
+function createApprovedReview() {
+  return {
+    slug: 'example-review',
+    status: 'approved',
+    published: false,
+    publishedAt: ''
+  };
+}
+
+test(
+  'publish action updates all publication fields together',
+  () => {
+    const result =
+      transitionReviewPublication(
+        createApprovedReview(),
+        'publish',
+        '2026-08-03T10:00:00.000Z'
+      );
+
+    assert.equal(
+      result.status,
+      'published'
+    );
+
+    assert.equal(
+      result.published,
+      true
+    );
+
+    assert.equal(
+      result.publishedAt,
+      '2026-08-03T10:00:00.000Z'
+    );
+
+    assertReviewPublicationInvariant(
+      result
+    );
+  }
+);
+
+test(
+  'unpublish action clears all publication fields together',
+  () => {
+    const result =
+      transitionReviewPublication(
+        {
+          slug: 'example-review',
+          status: 'published',
+          published: true,
+          publishedAt:
+            '2026-08-03T10:00:00.000Z'
+        },
+        'unpublish'
+      );
+
+    assert.equal(
+      result.status,
+      'approved'
+    );
+
+    assert.equal(
+      result.published,
+      false
+    );
+
+    assert.equal(
+      result.publishedAt,
+      ''
+    );
+
+    assertReviewPublicationInvariant(
+      result
+    );
+  }
+);
+
+test(
+  'publish action rejects reviews that are not approved',
+  () => {
+    assert.throws(
+      () => {
+        transitionReviewPublication(
+          {
+            slug: 'example-review',
+            status: 'draft',
+            published: false,
+            publishedAt: ''
+          },
+          'publish',
+          '2026-08-03T10:00:00.000Z'
+        );
+      },
+      /cannot be published from status "draft"/
+    );
+  }
+);
+
+test(
+  'publication invariant rejects independently enabled published flag',
+  () => {
+    assert.throws(
+      () => {
+        assertReviewPublicationInvariant({
+          slug: 'example-review',
+          status: 'approved',
+          published: true,
+          publishedAt:
+            '2026-08-03T10:00:00.000Z'
+        });
+      },
+      /must have status "published"/
+    );
+  }
+);
+
+test(
+  'publication invariant rejects published status without publication flag',
+  () => {
+    assert.throws(
+      () => {
+        assertReviewPublicationInvariant({
+          slug: 'example-review',
+          status: 'published',
+          published: false,
+          publishedAt: ''
+        });
+      },
+      /cannot have status "published"/
+    );
+  }
+);
+
+test(
+  'main CMS keeps technical publication fields hidden',
+  () => {
+    const configPath = path.join(
+      root,
+      'public',
+      'admin',
+      'config.yml'
+    );
+
+    const config =
+      fs.readFileSync(
+        configPath,
+        'utf8'
+      );
+
+    const collectionStart =
+      config.indexOf(
+        '  - name: "reviews"'
+      );
+
+    assert.notEqual(
+      collectionStart,
+      -1,
+      'Reviews collection was not found.'
+    );
+
+    const reviewsCollection =
+      config.slice(collectionStart);
+
+    assert.match(
+      reviewsCollection,
+      /name:\s*"status"\s*\r?\n\s+widget:\s*"hidden"/
+    );
+
+    assert.match(
+      reviewsCollection,
+      /name:\s*"published"\s*\r?\n\s+widget:\s*"hidden"/
+    );
+
+    assert.match(
+      reviewsCollection,
+      /name:\s*"publishedAt"\s*\r?\n\s+widget:\s*"hidden"/
+    );
+
+    assert.doesNotMatch(
+      reviewsCollection,
+      /label:\s*"Published",\s*value:\s*"published"/
+    );
+  }
+);
+
+test(
+  'package exposes safe publish and unpublish commands',
+  () => {
+    const packagePath = path.join(
+      root,
+      'package.json'
+    );
+
+    const packageJson =
+      JSON.parse(
+        fs.readFileSync(
+          packagePath,
+          'utf8'
+        )
+      );
+
+    assert.equal(
+      packageJson.scripts[
+        'reviews:publish'
+      ],
+      'node scripts/set-review-publication.mjs publish'
+    );
+
+    assert.equal(
+      packageJson.scripts[
+        'reviews:unpublish'
+      ],
+      'node scripts/set-review-publication.mjs unpublish'
+    );
+  }
+);


### PR DESCRIPTION
## Summary

- hides the technical review publication fields in the main CMS
- adds atomic publish and unpublish commands
- updates `status`, `published` and `publishedAt` together
- restores the original review file automatically if safety tests fail
- adds publication workflow unit tests
- preserves Oya's contributor submission workflow unchanged

## Safe publication commands

```bash
npm run reviews:publish -- <review-slug>
npm run reviews:unpublish -- <review-slug>