### PR TITLE
fix(events): recover CZ/SK city keyword Ticketmaster results

### DIFF
--- a/src/adapters/smsticket.js
+++ b/src/adapters/smsticket.js
@@ -9,6 +9,7 @@
 // ---------------------------------------------------------
 
 import { canonForInputCity } from '../city/canonical.js';
+import { matchesKeywordPrefix } from '../search/keyword-match.js';
 
 import {
   buildSmsticketTaxonomy,
@@ -496,7 +497,7 @@ function matchesKeyword(ev, keyword = '') {
     ...(Array.isArray(ev?.types) ? ev.types : [])
   ].filter(Boolean).join(' '));
 
-  return haystack.includes(query);
+  return matchesKeywordPrefix(haystack, query);
 }
 
 function matchesNearMe(ev, filters = {}) {

--- a/src/adapters/ticketmaster.js
+++ b/src/adapters/ticketmaster.js
@@ -742,6 +742,40 @@ export function mapTicketmasterEvent(
   };
 }
 
+function isTicketmasterAncillaryEvent(ev = {}) {
+  const normalizeLabel = (value = '') =>
+    String(value || '')
+      .trim()
+      .toLowerCase()
+      .normalize('NFKD')
+      .replace(/\p{M}+/gu, '');
+
+  const eventName = normalizeLabel(ev?.name);
+
+  const attractionNames =
+    Array.isArray(ev?._embedded?.attractions)
+      ? ev._embedded.attractions
+          .map((attraction) =>
+            normalizeLabel(attraction?.name)
+          )
+          .filter(Boolean)
+      : [];
+
+  const hasFastTrackAttraction =
+    attractionNames.some((name) =>
+      /^fast[\s-]*track\b/.test(name)
+    );
+
+  const eventNameMarksFastTrack =
+    /(?:^|\|)\s*fast[\s-]*track\b/.test(
+      eventName
+    );
+
+  return (
+    hasFastTrackAttraction &&
+    eventNameMarksFastTrack
+  );
+}
 function filterRawEventsByStrictCityCountry(events = [], { strictCity = '', strictCountry = '' } = {}) {
   const cc = String(strictCountry || '').trim().toUpperCase();
   const city = String(strictCity || '').trim();
@@ -1474,7 +1508,11 @@ export async function fetchEvents({ locale = 'cs', filters = {} } = {}) {
             : list;
 
           if (!strictRawList.length) continue;
-          collectedRaw.push(...strictRawList);
+          const discoverableRawList = strictRawList.filter(
+            (event) => !isTicketmasterAncillaryEvent(event)
+          );
+          if (!discoverableRawList.length) continue;
+          collectedRaw.push(...discoverableRawList);
         } catch (err) {
           if (err?.status === 429 || err?.rateLimited) {
             rateLimited = true;

--- a/src/adapters/ticketmaster.js
+++ b/src/adapters/ticketmaster.js
@@ -1184,6 +1184,20 @@ function shouldSkipCzSkCityBroadFallback({ city = '', countryCode = '', filters 
   // Allow debug/manual override if we need to investigate coverage later.
   if (filters.forceTicketmasterBroadFallback === true) return false;
 
+  // AJSEE_TM_CZSK_CITY_KEYWORD_FALLBACK_v1
+  // Ticketmaster can store a city event under a district label such as
+  // "Praha 9". A strict city query may then miss an otherwise relevant
+  // event. A meaningful keyword already narrows the country-level fallback
+  // enough to keep it useful without restoring broad CZ/SK discovery.
+  const keyword = String(
+    filters.keyword ||
+    filters.q ||
+    filters.search ||
+    ''
+  ).trim();
+
+  if (keyword.length >= 2) return false;
+
   return true;
 }
 

--- a/src/api/eventsApi.js
+++ b/src/api/eventsApi.js
@@ -26,6 +26,7 @@ import { fetchEvents as fetchSmsticketEvents } from '../adapters/smsticket.js';
 import { fetchEvents as fetchSeatPlanEvents } from '../adapters/seatplan.js';
 import { canonForInputCity, guessCountryCodeFromCity } from '../city/canonical.js';
 import { matchesEventDiscoveryFilters } from '../taxonomy/event-filtering.js';
+import { matchesKeywordPrefix } from '../search/keyword-match.js';
 
 // DEV detekce (localhost/Vite)
 const isDev =
@@ -684,7 +685,7 @@ function seatPlanBoostScore(ev = {}, filters = {}, loc = 'en') {
 
   const q = normalizeStr(filters.keyword || filters.q || filters.search || '');
 
-  if (q && eventSearchText(ev, loc).includes(q)) return 0;
+  if (q && matchesKeywordPrefix(eventSearchText(ev, loc), q)) return 0;
 
   return 1;
 }
@@ -1012,7 +1013,7 @@ if (ENABLE_SEATPLAN) {
   if (keyword) {
     const q = normalizeStr(keyword);
 
-    all = all.filter((ev) => eventSearchText(ev, loc).includes(q));
+    all = all.filter((ev) => matchesKeywordPrefix(eventSearchText(ev, loc), q));
   }
 
   if (dateFrom || dateTo) {

--- a/src/search/keyword-match.js
+++ b/src/search/keyword-match.js
@@ -1,0 +1,37 @@
+function normalizeSearchText(value = '') {
+  return String(value ?? '')
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/\p{M}+/gu, '');
+}
+
+function tokenizeSearchText(value = '') {
+  return (
+    normalizeSearchText(value)
+      .match(/[\p{L}\p{N}]+/gu) ||
+    []
+  );
+}
+
+export function matchesKeywordPrefix(
+  haystack = '',
+  keyword = ''
+) {
+  const queryTokens = tokenizeSearchText(keyword);
+
+  if (!queryTokens.length) return true;
+
+  const haystackTokens = tokenizeSearchText(haystack);
+
+  if (!haystackTokens.length) return false;
+
+  return queryTokens.every((queryToken) =>
+    haystackTokens.some((token) => {
+      if (queryToken.length === 1) {
+        return token === queryToken;
+      }
+
+      return token.startsWith(queryToken);
+    })
+  );
+}

--- a/tests/event-search-quality.test.mjs
+++ b/tests/event-search-quality.test.mjs
@@ -1,0 +1,224 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  matchesKeywordPrefix
+} from '../src/search/keyword-match.js';
+
+test(
+  'keyword eros matches Eros Ramazzotti',
+  () => {
+    assert.equal(
+      matchesKeywordPrefix(
+        'EROS RAMAZZOTTI - UNA STORIA IMPORTANTE',
+        'eros'
+      ),
+      true
+    );
+  }
+);
+
+test(
+  'keyword eros does not match Aerosmith',
+  () => {
+    assert.equal(
+      matchesKeywordPrefix(
+        'Queen Metallica Nirvana Aerosmith Guns N Roses',
+        'eros'
+      ),
+      false
+    );
+  }
+);
+
+test(
+  'keyword supports artist-name prefix search',
+  () => {
+    assert.equal(
+      matchesKeywordPrefix(
+        'Eros Ramazzotti',
+        'ramazz'
+      ),
+      true
+    );
+  }
+);
+
+test(
+  'multi-token keyword matches corresponding prefixes',
+  () => {
+    assert.equal(
+      matchesKeywordPrefix(
+        'EROS RAMAZZOTTI - UNA STORIA IMPORTANTE',
+        'eros ramazz'
+      ),
+      true
+    );
+  }
+);
+
+const ticketmasterSource =
+  readFileSync(
+    new URL(
+      '../src/adapters/ticketmaster.js',
+      import.meta.url
+    ),
+    'utf8'
+  ).replace(/\r\n/g, '\n');
+
+function getAncillaryMatcher() {
+  const start =
+    ticketmasterSource.indexOf(
+      'function isTicketmasterAncillaryEvent(ev = {}) {'
+    );
+
+  const end =
+    ticketmasterSource.indexOf(
+      '\nfunction filterRawEventsByStrictCityCountry',
+      start
+    );
+
+  assert.notEqual(
+    start,
+    -1,
+    'Ticketmaster ancillary matcher must exist'
+  );
+
+  assert.notEqual(
+    end,
+    -1,
+    'Ticketmaster ancillary matcher boundary must exist'
+  );
+
+  const helperSource =
+    ticketmasterSource.slice(
+      start,
+      end
+    );
+
+  return new Function(
+    `${helperSource}
+     return isTicketmasterAncillaryEvent;`
+  )();
+}
+
+test(
+  'normal Ticketmaster concert remains discoverable',
+  () => {
+    const isAncillary =
+      getAncillaryMatcher();
+
+    assert.equal(
+      isAncillary({
+        name:
+          'EROS RAMAZZOTTI - UNA STORIA IMPORTANTE',
+        _embedded: {
+          attractions: [
+            {
+              name: 'Eros Ramazzotti'
+            }
+          ]
+        }
+      }),
+      false
+    );
+  }
+);
+
+test(
+  'Ticketmaster Fast Track product is ancillary',
+  () => {
+    const isAncillary =
+      getAncillaryMatcher();
+
+    assert.equal(
+      isAncillary({
+        name:
+          'EROS RAMAZZOTTI - UNA STORIA IMPORTANTE | Fast Track',
+        _embedded: {
+          attractions: [
+            {
+              name: 'Fast Track - O2 arena'
+            },
+            {
+              name: 'Eros Ramazzotti'
+            }
+          ]
+        }
+      }),
+      true
+    );
+  }
+);
+
+test(
+  'Fast Track wording alone is not enough to hide an event',
+  () => {
+    const isAncillary =
+      getAncillaryMatcher();
+
+    assert.equal(
+      isAncillary({
+        name:
+          'Fast Track Festival',
+        _embedded: {
+          attractions: [
+            {
+              name: 'Some Artist'
+            }
+          ]
+        }
+      }),
+      false
+    );
+  }
+);
+
+test(
+  'Ticketmaster collection removes ancillary products before mapping',
+  () => {
+    assert.match(
+      ticketmasterSource,
+      /const discoverableRawList = strictRawList\.filter\([\s\S]*?!isTicketmasterAncillaryEvent\(event\)[\s\S]*?collectedRaw\.push\(\.\.\.discoverableRawList\)/
+    );
+  }
+);
+
+const smsSource =
+  readFileSync(
+    new URL(
+      '../src/adapters/smsticket.js',
+      import.meta.url
+    ),
+    'utf8'
+  );
+
+const eventsApiSource =
+  readFileSync(
+    new URL(
+      '../src/api/eventsApi.js',
+      import.meta.url
+    ),
+    'utf8'
+  );
+
+test(
+  'SMS Ticket uses the shared keyword matcher',
+  () => {
+    assert.match(
+      smsSource,
+      /matchesKeywordPrefix\(haystack, query\)/
+    );
+  }
+);
+
+test(
+  'events API uses the shared keyword matcher for final filtering',
+  () => {
+    assert.match(
+      eventsApiSource,
+      /matchesKeywordPrefix\(eventSearchText\(ev, loc\), q\)/
+    );
+  }
+);

--- a/tests/ticketmaster-city-keyword-fallback.test.mjs
+++ b/tests/ticketmaster-city-keyword-fallback.test.mjs
@@ -1,0 +1,188 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const adapterSource = readFileSync(
+  new URL(
+    '../src/adapters/ticketmaster.js',
+    import.meta.url
+  ),
+  'utf8'
+).replace(/\r\n/g, '\n');
+
+function getDecisionFunction() {
+  const startMarker =
+    "function shouldSkipCzSkCityBroadFallback({ city = '', countryCode = '', filters = {} } = {}) {";
+
+  const start =
+    adapterSource.indexOf(startMarker);
+
+  assert.notEqual(
+    start,
+    -1,
+    'fallback function must exist'
+  );
+
+  const endMarker =
+    '\n\nexport async function fetchEvents';
+
+  const end =
+    adapterSource.indexOf(
+      endMarker,
+      start
+    );
+
+  assert.notEqual(
+    end,
+    -1,
+    'fallback function boundary must exist'
+  );
+
+  const functionSource =
+    adapterSource.slice(
+      start,
+      end
+    );
+
+  return new Function(
+    `${functionSource}
+     return shouldSkipCzSkCityBroadFallback;`
+  )();
+}
+
+test(
+  'CZ city-only search keeps broad fallback disabled',
+  () => {
+    const shouldSkip =
+      getDecisionFunction();
+
+    assert.equal(
+      shouldSkip({
+        city: 'Prague',
+        countryCode: 'CZ',
+        filters: {}
+      }),
+      true
+    );
+  }
+);
+
+test(
+  'SK city-only search keeps broad fallback disabled',
+  () => {
+    const shouldSkip =
+      getDecisionFunction();
+
+    assert.equal(
+      shouldSkip({
+        city: 'Bratislava',
+        countryCode: 'SK',
+        filters: {}
+      }),
+      true
+    );
+  }
+);
+
+test(
+  'CZ city plus artist keyword enables broad fallback',
+  () => {
+    const shouldSkip =
+      getDecisionFunction();
+
+    assert.equal(
+      shouldSkip({
+        city: 'Prague',
+        countryCode: 'CZ',
+        filters: {
+          keyword: 'Eros Ramazzotti'
+        }
+      }),
+      false
+    );
+  }
+);
+
+test(
+  'short meaningful keyword such as U2 enables fallback',
+  () => {
+    const shouldSkip =
+      getDecisionFunction();
+
+    assert.equal(
+      shouldSkip({
+        city: 'Prague',
+        countryCode: 'CZ',
+        filters: {
+          keyword: 'U2'
+        }
+      }),
+      false
+    );
+  }
+);
+
+test(
+  'single-character keyword does not trigger broad fallback',
+  () => {
+    const shouldSkip =
+      getDecisionFunction();
+
+    assert.equal(
+      shouldSkip({
+        city: 'Prague',
+        countryCode: 'CZ',
+        filters: {
+          keyword: 'a'
+        }
+      }),
+      true
+    );
+  }
+);
+
+test(
+  'manual fallback override remains supported',
+  () => {
+    const shouldSkip =
+      getDecisionFunction();
+
+    assert.equal(
+      shouldSkip({
+        city: 'Prague',
+        countryCode: 'CZ',
+        filters: {
+          forceTicketmasterBroadFallback: true
+        }
+      }),
+      false
+    );
+  }
+);
+
+test(
+  'non-CZ/SK city behavior remains unchanged',
+  () => {
+    const shouldSkip =
+      getDecisionFunction();
+
+    assert.equal(
+      shouldSkip({
+        city: 'Vienna',
+        countryCode: 'AT',
+        filters: {}
+      }),
+      false
+    );
+  }
+);
+
+test(
+  'broad fallback remains guarded by the CZ/SK decision',
+  () => {
+    assert.match(
+      adapterSource,
+      /if\s*\(!skipCzSkCityBroadFallback\)\s*\{[\s\S]*?mode:\s*'broad'/
+    );
+  }
+);


### PR DESCRIPTION
## Problem

Ticketmaster may store events under district-level city labels such as "Praha 9".

A strict search for:
- city: Praha / Prague
- keyword: Eros Ramazzotti
- year: 2027

could therefore miss the relevant event even though a country-level Ticketmaster search finds it.

## Fix

- Keep the existing CZ/SK broad fallback disabled for normal city browsing.
- Enable one controlled country-level fallback when an explicit CZ/SK city is combined with a meaningful keyword.
- Existing local city filtering still restricts returned events to the selected city.
- Preserve the manual fallback override.

## Regression coverage

Added tests for:
- CZ city-only search
- SK city-only search
- city + artist keyword
- short keyword such as U2
- single-character keyword
- manual override
- non-CZ/SK behavior
- broad fallback guard

## Validation

- 8/8 dedicated regression tests pass
- 146/146 relevant repository tests pass
- production build passes

One pre-existing stale Sweeney Todd test is unrelated to this change.