### PR TITLE
feat(events): improve venue information on cards and modal

### DIFF
--- a/src/adapters/ticketmaster.js
+++ b/src/adapters/ticketmaster.js
@@ -688,6 +688,9 @@ export function mapTicketmasterEvent(
   const country = venue?.country?.countryCode || '';
 
   const selectedCity = String(context.selectedCity || '').trim();
+  const selectedDisplayCity = String(
+    context.selectedDisplayCity || selectedCity
+  ).trim();
   const selectedCountry = String(context.selectedCountry || '').trim().toUpperCase();
 
   const displayCity =
@@ -697,7 +700,7 @@ export function mapTicketmasterEvent(
     String(country).toUpperCase() === selectedCountry &&
     actualCity &&
     isSameCityOrMetro(actualCity, selectedCity, selectedCountry)
-      ? selectedCity
+      ? selectedDisplayCity
       : actualCity;
 
   const latRaw = venue?.location?.latitude ?? venue?.location?.lat ?? '';
@@ -1560,6 +1563,13 @@ export async function fetchEvents({ locale = 'cs', filters = {} } = {}) {
 
   return dedupedRaw.map((ev) => mapTicketmasterEvent(ev, locale, {
     selectedCity: tmCity,
+    selectedDisplayCity: String(
+      filters.cityLabel ||
+      filters.city ||
+      rawCity ||
+      tmCity ||
+      ''
+    ).trim(),
     selectedCountry: selectedCityCountry
   }));
 }

--- a/src/event-location.js
+++ b/src/event-location.js
@@ -1,0 +1,115 @@
+function text(value) {
+  return String(value ?? '').trim();
+}
+
+function comparable(value) {
+  return text(value)
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/\p{M}+/gu, '');
+}
+
+export function resolveEventLocation(event = {}) {
+  const location =
+    event?.location && typeof event.location === 'object'
+      ? event.location
+      : {};
+
+  const venue =
+    event?.venue && typeof event.venue === 'object'
+      ? event.venue
+      : {};
+
+  const place =
+    event?.place && typeof event.place === 'object'
+      ? event.place
+      : {};
+
+  const locationString =
+    typeof event?.location === 'string'
+      ? text(event.location)
+      : '';
+
+  const venueName = text(
+    venue?.name ||
+    place?.company ||
+    event?.venueName ||
+    place?.name ||
+    ''
+  );
+
+  const city = text(
+    location?.city ||
+    venue?.city ||
+    place?.city ||
+    locationString ||
+    ''
+  );
+
+  const actualCity = text(
+    location?.actualCity ||
+    venue?.city ||
+    place?.city ||
+    city
+  );
+
+  const country = text(
+    location?.country ||
+    venue?.country ||
+    place?.country ||
+    event?.countryCode ||
+    ''
+  );
+
+  return {
+    venueName,
+    city,
+    actualCity,
+    country
+  };
+}
+
+export function formatEventVenueLine(event = {}) {
+  const {
+    venueName,
+    city
+  } = resolveEventLocation(event);
+
+  if (!venueName) return city;
+  if (!city) return venueName;
+
+  if (comparable(venueName) === comparable(city)) {
+    return venueName;
+  }
+
+  return `${venueName} · ${city}`;
+}
+export function formatEventCalendarLocation(event = {}) {
+  const {
+    venueName,
+    city,
+    actualCity,
+    country
+  } = resolveEventLocation(event);
+
+  const rawParts = [
+    venueName,
+    actualCity || city,
+    country
+  ].filter(Boolean);
+
+  const seen = new Set();
+
+  return rawParts
+    .filter((part) => {
+      const key = comparable(part);
+
+      if (!key || seen.has(key)) {
+        return false;
+      }
+
+      seen.add(key);
+      return true;
+    })
+    .join(', ');
+}

--- a/src/event-modal.js
+++ b/src/event-modal.js
@@ -118,7 +118,48 @@ const MODAL_I18N = {
   },
 };
 
-function normalizeLang(locale = '') {
+const MODAL_TICKET_SELLER_LABELS = {
+  cs: 'Prodejce vstupenek',
+  en: 'Ticket seller',
+  de: 'Ticketanbieter',
+  sk: 'Predajca vstupeniek',
+  pl: 'Sprzedawca biletów',
+  hu: 'Jegyértékesítő'
+};
+
+function modalProviderName(eventData = {}) {
+  const raw = String(
+    eventData?.sourceName ||
+    eventData?.partner ||
+    eventData?.source ||
+    ''
+  ).trim();
+
+  const key = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '');
+
+  const known = {
+    ticketmaster: 'Ticketmaster',
+    smsticket: 'SMS Ticket',
+    todaytix: 'TodayTix',
+    seatplan: 'SeatPlan'
+  };
+
+  return known[key] || raw;
+}
+
+function formatModalTicketSeller(lang, provider) {
+  const cleanProvider = String(provider || '').trim();
+
+  if (!cleanProvider) return '';
+
+  const label =
+    MODAL_TICKET_SELLER_LABELS[lang] ||
+    MODAL_TICKET_SELLER_LABELS.cs;
+
+  return `${label}: ${cleanProvider}`;
+}function normalizeLang(locale = '') {
   const lang = String(locale || document.documentElement.lang || 'cs')
     .trim()
     .toLowerCase()
@@ -932,7 +973,97 @@ function ensureTicketOptionsStyles() {
   `);
 }
 
-function ensureEventModalShell() {
+function ensureModalConversionPolishStyles() {
+  injectOnce('ajsee-event-modal-conversion-polish-v1-css', String.raw`
+    .event-modal .modal-title{
+      font-size:clamp(28px, 3vw, 38px);
+      line-height:1.08;
+      letter-spacing:-.03em;
+    }
+
+    .event-modal .modal-description[hidden]{
+      display:none !important;
+    }
+
+    .event-modal .modal-category{
+      margin-bottom:16px;
+      color:#667085;
+      font-size:13px;
+      font-style:normal !important;
+      font-weight:700;
+    }
+
+    .event-modal .modal-seller-note{
+      margin:10px 0 20px;
+      color:#667085;
+      font-size:13px;
+      line-height:1.45;
+      font-weight:600;
+    }
+
+    .event-modal .calendar-buttons{
+      margin-top:20px;
+    }
+
+    .event-modal .calendar-label{
+      margin-bottom:8px;
+      color:#526071;
+      font-size:14px;
+      font-weight:750;
+    }
+
+    .event-modal .calendar-btns-wrap,
+    .event-modal .ajsee-modal-calendar-actions-v1{
+      display:flex !important;
+      flex-wrap:wrap !important;
+      gap:8px !important;
+      width:100% !important;
+    }
+
+    .event-modal .calendar-btn,
+    .event-modal .ajsee-modal-calendar-actions-v1 > a,
+    .event-modal .ajsee-modal-calendar-actions-v1 > button{
+      width:auto !important;
+      min-width:0 !important;
+      min-height:38px !important;
+      padding:0 12px !important;
+      border:1px solid rgba(10,61,98,.18) !important;
+      border-radius:10px !important;
+      background:#fff !important;
+      color:#0A3D62 !important;
+      box-shadow:none !important;
+      font-size:14px !important;
+      font-weight:750 !important;
+      justify-self:start !important;
+    }
+
+    .event-modal .calendar-btn:hover,
+    .event-modal .ajsee-modal-calendar-actions-v1 > a:hover,
+    .event-modal .ajsee-modal-calendar-actions-v1 > button:hover{
+      border-color:rgba(10,61,98,.32) !important;
+      background:#f5f9fd !important;
+    }
+
+    .event-modal .calendar-btn:focus-visible{
+      outline:3px solid rgba(14,136,240,.28);
+      outline-offset:3px;
+    }
+
+    @media (max-width:760px){
+      .event-modal .modal-title{
+        font-size:clamp(26px, 8vw, 30px);
+      }
+
+      .event-modal .modal-ticket-cta{
+        width:100%;
+      }
+
+      .event-modal .modal-seller-note{
+        margin-top:8px;
+      }
+    }
+  `);
+}function ensureEventModalShell() {
   ensureModalStyles();
 
   let modal = document.getElementById(MODAL_ID);
@@ -982,6 +1113,12 @@ function ensureEventModalShell() {
           <a id="modalTicketsLink" class="modal-ticket-cta" href="#" target="_blank" rel="noopener noreferrer">
             Vstupenky
           </a>
+
+          <p
+            id="modalSellerNote"
+            class="modal-seller-note"
+            hidden
+          ></p>
 
           <div class="calendar-buttons">
             <span class="calendar-label" id="modalCalendarLabel">Přidat do kalendáře:</span>
@@ -1139,6 +1276,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
   const lang = normalizeLang(locale);
   const intlLocale = browserLocale(locale);
   const modal = ensureEventModalShell();
+  ensureModalConversionPolishStyles();
 
   if (!window.__ajseeEventModalInitialized) {
     initEventModal();
@@ -1168,8 +1306,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
     i18n(lang, 'untitled');
 
   const description =
-    pickLocalized(eventData.description, preferredLocales) ||
-    i18n(lang, 'detailsFallback');
+    pickLocalized(eventData.description, preferredLocales).trim();
 
   const dateVal = eventData.datetime || eventData.date || '';
   const dateObj = parseEventDate(dateVal);
@@ -1220,6 +1357,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
   const dateEl = modal.querySelector('#modalDate');
   const locationEl = modal.querySelector('#modalLocation');
   const descEl = modal.querySelector('#modalDescription');
+  const sellerNoteEl = modal.querySelector('#modalSellerNote');
   const categoryEl = modal.querySelector('#modalCategory');
   const ticketEl = modal.querySelector('#modalTicketsLink');
   const ticketOptionsEl = modal.querySelector('#modalTicketOptions');
@@ -1233,8 +1371,19 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
 
   if (dateEl) dateEl.textContent = dateText;
   if (locationEl) locationEl.textContent = locationText;
-  if (descEl) descEl.textContent = description;
+  if (descEl) {
+    descEl.textContent = description;
+    descEl.hidden = !description;
+  }
   if (categoryEl) categoryEl.textContent = translateCategory(eventData.category, lang);
+
+  const sellerName = modalProviderName(eventData);
+
+  if (sellerNoteEl) {
+    sellerNoteEl.textContent =
+      formatModalTicketSeller(lang, sellerName);
+    sellerNoteEl.hidden = !sellerName;
+  }
 
   const renderedTicketOptions =
     ticketOptions.length > 1

--- a/src/event-modal.js
+++ b/src/event-modal.js
@@ -1,3 +1,8 @@
+import {
+  resolveEventLocation,
+  formatEventVenueLine,
+  formatEventCalendarLocation
+} from './event-location.js';
 // /src/event-modal.js
 // ---------------------------------------------------------
 // AJSEE – Event modal
@@ -1177,13 +1182,17 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
       })
     : '';
 
-  const locationObj = eventData.location || {};
-  const locationText = typeof locationObj === 'string'
-    ? locationObj
-    : [
-        locationObj?.city || '',
-        locationObj?.country || '',
-      ].filter(Boolean).join(', ');
+  const resolvedLocation =
+    resolveEventLocation(eventData);
+
+  const locationText =
+    formatEventVenueLine(eventData);
+
+  const calendarLocationText =
+    formatEventCalendarLocation(eventData);
+
+  const locationObj =
+    eventData.location || {};
 
   const image =
     eventData.image ||
@@ -1307,7 +1316,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
         text: title,
         dates: `${toCalDate(start)}/${toCalDate(end)}`,
         details: description,
-        location: locationText,
+        location: calendarLocationText,
       });
 
       googleLink.href = `https://calendar.google.com/calendar/render?${googleParams.toString()}`;
@@ -1320,7 +1329,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
         ri: '0',
         subject: title,
         body: description,
-        location: locationText,
+        location: calendarLocationText,
       });
 
       outlookLink.href = `https://outlook.office.com/calendar/0/deeplink/compose?${outlookParams.toString()}`;
@@ -1331,7 +1340,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
       const icsText = buildICS({
         title,
         description,
-        location: locationText,
+        location: calendarLocationText,
         start,
         end,
       });

--- a/src/event-modal.js
+++ b/src/event-modal.js
@@ -1049,6 +1049,27 @@ function ensureModalConversionPolishStyles() {
       outline-offset:3px;
     }
 
+    /* AJSEE_MODAL_CALENDAR_3COL_V1 */
+    @media (min-width:761px){
+      .event-modal .calendar-btns-wrap,
+      .event-modal .ajsee-modal-calendar-actions-v1{
+        display:grid !important;
+        grid-template-columns:repeat(3, minmax(0, 1fr)) !important;
+        gap:8px !important;
+        width:100% !important;
+      }
+
+      .event-modal .calendar-btn,
+      .event-modal .ajsee-modal-calendar-actions-v1 > a,
+      .event-modal .ajsee-modal-calendar-actions-v1 > button{
+        width:100% !important;
+        min-width:0 !important;
+        padding:0 8px !important;
+        font-size:13px !important;
+        white-space:nowrap !important;
+      }
+    }
+
     @media (max-width:760px){
       .event-modal .modal-title{
         font-size:clamp(26px, 8vw, 30px);
@@ -1060,6 +1081,20 @@ function ensureModalConversionPolishStyles() {
 
       .event-modal .modal-seller-note{
         margin-top:8px;
+      }
+
+      /* AJSEE_MODAL_CALENDAR_MOBILE_1COL_V1 */
+      .event-modal .calendar-btns-wrap,
+      .event-modal .ajsee-modal-calendar-actions-v1{
+        display:grid !important;
+        grid-template-columns:1fr !important;
+        width:100% !important;
+      }
+
+      .event-modal .calendar-btn,
+      .event-modal .ajsee-modal-calendar-actions-v1 > a,
+      .event-modal .ajsee-modal-calendar-actions-v1 > button{
+        width:100% !important;
       }
     }
   `);
@@ -1149,6 +1184,45 @@ function ensureModalConversionPolishStyles() {
   ensureTicketOptionsStyles();
 
   return modal;
+}
+
+function ensureModalSellerNote(modal) {
+  if (!modal) return null;
+
+  let note =
+    modal.querySelector('#modalSellerNote');
+
+  if (note) return note;
+
+  note = document.createElement('p');
+  note.id = 'modalSellerNote';
+  note.className = 'modal-seller-note';
+  note.hidden = true;
+
+  const calendar =
+    modal.querySelector('.calendar-buttons');
+
+  const ticket =
+    modal.querySelector('#modalTicketsLink');
+
+  const details =
+    modal.querySelector('.modal-details');
+
+  if (calendar?.parentNode) {
+    calendar.parentNode.insertBefore(
+      note,
+      calendar
+    );
+  } else if (ticket?.parentNode) {
+    ticket.parentNode.insertBefore(
+      note,
+      ticket.nextSibling
+    );
+  } else if (details) {
+    details.appendChild(note);
+  }
+
+  return note;
 }
 
 function ensureTicketCta(modal) {
@@ -1357,7 +1431,7 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
   const dateEl = modal.querySelector('#modalDate');
   const locationEl = modal.querySelector('#modalLocation');
   const descEl = modal.querySelector('#modalDescription');
-  const sellerNoteEl = modal.querySelector('#modalSellerNote');
+  const sellerNoteEl = ensureModalSellerNote(modal);
   const categoryEl = modal.querySelector('#modalCategory');
   const ticketEl = modal.querySelector('#modalTicketsLink');
   const ticketOptionsEl = modal.querySelector('#modalTicketOptions');

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -4857,6 +4857,28 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
 
     injectProviderBadgeStyles();
 
+    /*
+     * Keep event cards at a stable product-card width.
+     * auto-fill keeps empty grid tracks reserved, unlike auto-fit,
+     * so a single result does not stretch across the full 1200px container.
+     * Non-card states still span the complete result grid.
+     */
+    injectOnce('ajsee-events-card-grid-v1-css', String.raw`
+      #eventsList.events-list{
+        grid-template-columns:
+          repeat(
+            auto-fill,
+            minmax(min(100%, 360px), 24rem)
+          );
+        justify-content:start;
+      }
+
+      #eventsList.events-list > :not(.event-card){
+        grid-column:1 / -1;
+        width:100%;
+      }
+    `);
+
 
     const modalStore = new Map();
 

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -34,6 +34,7 @@ import { canonForInputCity, guessCountryCodeFromCity } from './city/canonical.js
 import { getSortedBlogArticles } from './blogArticles.js';
 import { initNav } from './nav-core.js';
 import { initContactFormValidation } from './contact-validate.js';
+import { formatEventVenueLine } from './event-location.js';
 import { initEventModal, openEventModal } from './event-modal.js';
 import { ensureRuntimeStyles, updateHeaderOffset } from './runtime-style.js';
 
@@ -4884,6 +4885,10 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
       const ticketLabel = esc(t('event-tickets', 'Vstupenky'));
       const provider = ajseeEventProviderKey(ev);
       const providerBadge = eventProviderBadgeHtml(ev, locale);
+      const venueLine = formatEventVenueLine(ev);
+      const venueLineHtml = venueLine
+        ? `<p class="event-date event-location">${esc(venueLine)}</p>`
+        : '';
       const eventCityAttr = esc(ev?.location?.city || ev?.venue?.city || ev?.place?.city || '');
       const eventTitleAttr = esc(titleRaw);
 
@@ -4893,6 +4898,7 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
           <div class="event-content">
             <h3 class="event-title">${title}</h3>
             <p class="event-date">${date}</p>
+            ${venueLineHtml}
             ${providerBadge}
             <div class="event-buttons-group">
               <button type="button" class="btn-event detail js-event-detail" data-event-id="${esc(modalId)}">

--- a/tests/event-card-modal-polish.test.mjs
+++ b/tests/event-card-modal-polish.test.mjs
@@ -1,0 +1,88 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const eventsSource = readFileSync(
+  new URL('../src/events-entry.js', import.meta.url),
+  'utf8'
+);
+
+const modalSource = readFileSync(
+  new URL('../src/event-modal.js', import.meta.url),
+  'utf8'
+);
+
+const ticketmasterSource = readFileSync(
+  new URL('../src/adapters/ticketmaster.js', import.meta.url),
+  'utf8'
+);
+
+test('single event result keeps a stable desktop card track', () => {
+  assert.match(
+    eventsSource,
+    /repeat\(\s*auto-fill,\s*minmax\(\s*min\(100%,\s*360px\),\s*24rem\s*\)\s*\)/
+  );
+
+  assert.match(
+    eventsSource,
+    /#eventsList\.events-list\s*>\s*:not\(\.event-card\)/
+  );
+});
+
+test('Ticketmaster query city is separated from display city', () => {
+  assert.match(
+    ticketmasterSource,
+    /selectedDisplayCity/
+  );
+
+  assert.match(
+    ticketmasterSource,
+    /\?\s*selectedDisplayCity\s*:\s*actualCity/
+  );
+
+  assert.match(
+    ticketmasterSource,
+    /filters\.cityLabel\s*\|\|\s*filters\.city/
+  );
+});
+
+test('modal hides missing descriptions instead of showing fallback text', () => {
+  assert.match(
+    modalSource,
+    /pickLocalized\(eventData\.description,\s*preferredLocales\)\.trim\(\)/
+  );
+
+  assert.match(
+    modalSource,
+    /descEl\.hidden\s*=\s*!description/
+  );
+
+  assert.doesNotMatch(
+    modalSource,
+    /i18n\(lang,\s*'detailsFallback'\)/
+  );
+});
+
+test('modal exposes ticket seller trust information', () => {
+  assert.match(
+    modalSource,
+    /modalSellerNote/
+  );
+
+  assert.match(
+    modalSource,
+    /formatModalTicketSeller/
+  );
+});
+
+test('modal uses secondary calendar styling', () => {
+  assert.match(
+    modalSource,
+    /ajsee-event-modal-conversion-polish-v1-css/
+  );
+
+  assert.match(
+    modalSource,
+    /background:#fff !important/
+  );
+});

--- a/tests/event-card-modal-polish.test.mjs
+++ b/tests/event-card-modal-polish.test.mjs
@@ -86,3 +86,38 @@ test('modal uses secondary calendar styling', () => {
     /background:#fff !important/
   );
 });
+test('existing modal shell receives seller trust note at runtime', () => {
+  assert.match(
+    modalSource,
+    /function ensureModalSellerNote\(modal\)/
+  );
+
+  assert.match(
+    modalSource,
+    /const sellerNoteEl = ensureModalSellerNote\(modal\)/
+  );
+});
+
+test('desktop calendar actions use three compact columns', () => {
+  assert.match(
+    modalSource,
+    /AJSEE_MODAL_CALENDAR_3COL_V1/
+  );
+
+  assert.match(
+    modalSource,
+    /grid-template-columns:repeat\(3,\s*minmax\(0,\s*1fr\)\)/
+  );
+});
+
+test('mobile calendar actions remain one column', () => {
+  assert.match(
+    modalSource,
+    /AJSEE_MODAL_CALENDAR_MOBILE_1COL_V1/
+  );
+
+  assert.match(
+    modalSource,
+    /grid-template-columns:1fr !important/
+  );
+});

--- a/tests/event-location-display.test.mjs
+++ b/tests/event-location-display.test.mjs
@@ -1,0 +1,171 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  resolveEventLocation,
+  formatEventVenueLine,
+  formatEventCalendarLocation
+} from '../src/event-location.js';
+
+test('Ticketmaster prefers display city while preserving actual venue city', () => {
+  const event = {
+    location: {
+      city: 'Praha',
+      actualCity: 'Praha 9',
+      country: 'CZ'
+    },
+    venue: {
+      name: 'O2 arena',
+      city: 'Praha 9'
+    }
+  };
+
+  assert.deepEqual(
+    resolveEventLocation(event),
+    {
+      venueName: 'O2 arena',
+      city: 'Praha',
+      actualCity: 'Praha 9',
+      country: 'CZ'
+    }
+  );
+
+  assert.equal(
+    formatEventVenueLine(event),
+    'O2 arena · Praha'
+  );
+});
+
+test('SMS Ticket supports venue.name and venue.city', () => {
+  const event = {
+    venue: {
+      name: 'Sono Centrum',
+      city: 'Brno'
+    }
+  };
+
+  assert.equal(
+    formatEventVenueLine(event),
+    'Sono Centrum · Brno'
+  );
+});
+
+test('SMS Ticket falls back to place.company and place.city', () => {
+  const event = {
+    place: {
+      company: 'Divadlo ABC',
+      city: 'Praha'
+    }
+  };
+
+  assert.equal(
+    formatEventVenueLine(event),
+    'Divadlo ABC · Praha'
+  );
+});
+
+test('legacy venueName is supported', () => {
+  const event = {
+    venueName: 'Kulturní dům',
+    location: {
+      city: 'Hodonín',
+      country: 'CZ'
+    }
+  };
+
+  assert.equal(
+    formatEventVenueLine(event),
+    'Kulturní dům · Hodonín'
+  );
+});
+
+test('city-only event remains useful', () => {
+  const event = {
+    location: {
+      city: 'Ostrava',
+      country: 'CZ'
+    }
+  };
+
+  assert.equal(
+    formatEventVenueLine(event),
+    'Ostrava'
+  );
+});
+
+test('venue-only event remains useful', () => {
+  const event = {
+    venue: {
+      name: 'Royal Albert Hall'
+    }
+  };
+
+  assert.equal(
+    formatEventVenueLine(event),
+    'Royal Albert Hall'
+  );
+});
+
+test('venue and city are not duplicated when identical', () => {
+  const event = {
+    venue: {
+      name: 'Brno'
+    },
+    location: {
+      city: 'Brno'
+    }
+  };
+
+  assert.equal(
+    formatEventVenueLine(event),
+    'Brno'
+  );
+});
+
+test('string location remains supported as a fallback', () => {
+  const event = {
+    location: 'London'
+  };
+
+  assert.deepEqual(
+    resolveEventLocation(event),
+    {
+      venueName: '',
+      city: 'London',
+      actualCity: 'London',
+      country: ''
+    }
+  );
+});
+test('Ticketmaster calendar keeps the precise venue city', () => {
+  const event = {
+    location: {
+      city: 'Praha',
+      actualCity: 'Praha 9',
+      country: 'CZ'
+    },
+    venue: {
+      name: 'O2 arena',
+      city: 'Praha 9'
+    }
+  };
+
+  assert.equal(
+    formatEventCalendarLocation(event),
+    'O2 arena, Praha 9, CZ'
+  );
+});
+
+test('SMS Ticket calendar location uses venue and city', () => {
+  const event = {
+    venue: {
+      name: 'Sono Centrum',
+      city: 'Brno'
+    }
+  };
+
+  assert.equal(
+    formatEventCalendarLocation(event),
+    'Sono Centrum, Brno'
+  );
+});


### PR DESCRIPTION
## Summary

Improves event-location clarity across the discovery flow.

### Changes
- adds a shared event-location resolver
- shows venue + display city on event cards
- shows venue + display city in the event detail modal
- preserves the more precise actual venue city for calendar exports
- supports Ticketmaster and SMS Ticket location fallbacks consistently
- prevents duplicate venue/city labels

### Examples
- Ticketmaster UI: `O2 arena · Praha`
- Calendar export: `O2 arena, Praha 9, CZ`

### QA
- event-location tests: 10/10 passing
- existing events/search regression suite: 49/49 passing
- `git diff --check`: PASS

### Visual QA remaining
- event card hierarchy
- event modal hierarchy
- venue readability on desktop/mobile