### PR TITLE
feat(analytics): unify ticket outbound click context

### DIFF
--- a/src/event-modal.js
+++ b/src/event-modal.js
@@ -693,6 +693,11 @@ function trackModalPartnerClickFromLink(link) {
   const partner =
     modalTrackingText(link.dataset.partner);
 
+  const eventId =
+    modalTrackingText(
+      link.dataset.eventId
+    );
+
   const eventName =
     modalTrackingText(
       link.dataset.eventTitle
@@ -758,6 +763,7 @@ function trackModalPartnerClickFromLink(link) {
 
     // Existing analytics contract.
     partner,
+    event_id: eventId,
     event_name: eventName,
     city,
     outbound_url: outboundUrl,
@@ -922,6 +928,12 @@ function renderModalTicketOptions(
 
     link.dataset.partner =
       option.provider || eventData?.partner || '';
+
+    link.dataset.eventId = String(
+      eventData?.id ||
+      eventData?.__ajseeModalId ||
+      ''
+    ).trim();
 
     link.dataset.eventTitle = title;
     link.dataset.eventCity = eventCity;
@@ -1482,6 +1494,12 @@ export async function openEventModal(eventData, locale = 'cs', opts = {}) {
     ticketEl.dataset.partner = String(
       eventData?.partner ||
       eventData?.source ||
+      ''
+    ).trim();
+
+    ticketEl.dataset.eventId = String(
+      eventData?.id ||
+      eventData?.__ajseeModalId ||
       ''
     ).trim();
 

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -4144,10 +4144,12 @@ function trackPartnerClickFromLink(link) {
       .toLowerCase() || 'cs';
 
   const partner = cleanText(link.dataset.partner);
+  const eventId = cleanText(link.dataset.eventId);
   const eventName = cleanText(link.dataset.eventTitle);
   const city = cleanText(link.dataset.eventCity);
   const clickedHref = cleanText(link.href || link.getAttribute('href'));
   const outboundUrl = cleanText(link.dataset.outboundUrl) || clickedHref;
+  const placement = cleanText(link.dataset.placement) || 'event_card';
 
   let routeCity = '';
   let routeCountryCode = '';
@@ -4171,10 +4173,11 @@ function trackPartnerClickFromLink(link) {
 
     // Existing fields kept for backward compatibility.
     partner,
+    event_id: eventId,
     event_name: eventName,
     city,
     outbound_url: outboundUrl,
-    placement: 'event_card',
+    placement,
     page_path: window.location.pathname + window.location.search,
     ts: new Date().toISOString(),
 
@@ -4926,7 +4929,7 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
               <button type="button" class="btn-event detail js-event-detail" data-event-id="${esc(modalId)}">
                 ${detailLabel}
               </button>
-              <a href="${ticketsHref}" class="btn-event ticket js-partner-click" target="_blank" rel="noopener noreferrer" data-partner="${esc(provider)}" data-event-title="${eventTitleAttr}" data-event-city="${eventCityAttr}" data-outbound-url="${ticketsHref}">
+              <a href="${ticketsHref}" class="btn-event ticket js-partner-click" target="_blank" rel="noopener noreferrer" data-partner="${esc(provider)}" data-event-id="${esc(modalId)}" data-placement="event_card" data-event-title="${eventTitleAttr}" data-event-city="${eventCityAttr}" data-outbound-url="${ticketsHref}">
                 ${ticketLabel}
               </a>
             </div>

--- a/tests/ticket-outbound-analytics.test.mjs
+++ b/tests/ticket-outbound-analytics.test.mjs
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const eventsEntrySource = fs.readFileSync(
+  new URL('../src/events-entry.js', import.meta.url),
+  'utf8'
+);
+
+const eventModalSource = fs.readFileSync(
+  new URL('../src/event-modal.js', import.meta.url),
+  'utf8'
+);
+
+test(
+  'event card exposes event identity and explicit analytics placement',
+  () => {
+    assert.match(
+      eventsEntrySource,
+      /data-event-id="\$\{esc\(modalId\)\}"/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /data-placement="event_card"/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /const eventId = cleanText\(link\.dataset\.eventId\);/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /const placement = cleanText\(link\.dataset\.placement\) \|\| 'event_card';/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /event_id:\s*eventId,/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /\bplacement,/
+    );
+  }
+);
+
+test(
+  'event modal exposes event id in partner_click contract',
+  () => {
+    assert.match(
+      eventModalSource,
+      /const eventId =\s*modalTrackingText\(\s*link\.dataset\.eventId\s*\);/
+    );
+
+    assert.match(
+      eventModalSource,
+      /event_id:\s*eventId,/
+    );
+
+    const assignments =
+      eventModalSource.match(
+        /dataset\.eventId\s*=/g
+      ) || [];
+
+    assert.ok(
+      assignments.length >= 2,
+      'Primary CTA and ticket-option CTA must expose event id.'
+    );
+  }
+);
+
+test(
+  'event card guards pointerdown plus click against duplicate tracking',
+  () => {
+    assert.match(
+      eventsEntrySource,
+      /let tracked = false;/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /if \(tracked\) return;\s*tracked = true;\s*trackPartnerClickFromLink\(link\);/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /addEventListener\('pointerdown', trackOnce/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /addEventListener\('click', trackOnce\)/
+    );
+  }
+);
+
+test(
+  'Ticketmaster outbound attribution remains event_card',
+  () => {
+    assert.match(
+      eventsEntrySource,
+      /withOutboundTracking\(ev\.tickets \|\| ev\.url \|\| '', \{ sourcePage, placement: 'event_card' \}\)/
+    );
+
+    assert.match(
+      eventsEntrySource,
+      /u\.searchParams\.set\('placement', placement\);/
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Unifies ticket outbound analytics context across event cards and the event modal.

### Changes
- adds `event_id` to the existing `partner_click` analytics payload
- exposes explicit `data-placement="event_card"` on event card ticket CTAs
- keeps `event_card` and `event_modal` attribution consistent
- preserves the existing `partner_click` dataLayer contract
- preserves Ticketmaster `tmOutbound` affiliate attribution
- preserves SMS Ticket outbound URLs
- keeps pointerdown + click deduplication on event cards

### Analytics contract

Key fields now include:

- `event`
- `event_id`
- `event_name`
- `partner`
- `placement`
- `event_city`
- `route_city`
- `route_country_code`
- `language`
- `destination_host`
- `page_path`
- ticket option context where applicable

### QA
- targeted regression suite: 86/86 PASS
- `git diff --check`: PASS
- working tree clean

### Runtime QA remaining
- verify `partner_click` from event card uses `placement: event_card`
- verify `partner_click` from modal uses `placement: event_modal`
- verify both clicks contain the same event ID