### PR TITLE
fix(events): enable global Ticketmaster keyword discovery

### DIFF
--- a/src/adapters/ticketmaster.js
+++ b/src/adapters/ticketmaster.js
@@ -1308,13 +1308,20 @@ export async function fetchEvents({ locale = 'cs', filters = {} } = {}) {
       ''
     );
   const debugTm = shouldDebugTicketmaster(filters);
-  const locales = makeLocaleList({
-    marketLocale,
-    locale,
-    debug: debugTm,
-    countryCode: targetCountryForLocale,
-    hasCity: Boolean(tmCity)
-  });
+  // AJSEE_TM_GLOBAL_KEYWORD_LOCALE_v1
+  // Cross-market artist discovery must not be constrained by the UI locale.
+  // Ticketmaster locale="*" exposes international results while all normal
+  // city/country/default discovery keeps the existing market locale logic.
+  const locales =
+    allowGlobalKeywordSearch
+      ? ['*']
+      : makeLocaleList({
+          marketLocale,
+          locale,
+          debug: debugTm,
+          countryCode: targetCountryForLocale,
+          hasCity: Boolean(tmCity)
+        });
 
   const putCommonParams = (qs, categoryVariant = {}) => {
     if (filters.keyword) qs.set('keyword', String(filters.keyword));

--- a/src/adapters/ticketmaster.js
+++ b/src/adapters/ticketmaster.js
@@ -1266,6 +1266,26 @@ export async function fetchEvents({ locale = 'cs', filters = {} } = {}) {
     ? String(filters.cityCountryCode || guessedCC || explicitCountry || '').toUpperCase()
     : '';
 
+  // AJSEE_TM_GLOBAL_KEYWORD_DISCOVERY_v1
+  // This must be an explicit upstream opt-in so normal no-city discovery
+  // keeps its existing default-country behaviour.
+  const globalKeyword = String(
+    filters.keyword ||
+    filters.q ||
+    filters.search ||
+    ''
+  ).trim();
+
+  const allowGlobalKeywordSearch =
+    filters.globalKeywordSearch === true &&
+    !effectiveRawCity &&
+    globalKeyword.length >= 2 &&
+    !filters.latlong &&
+    !(
+      filters.nearMeLat != null &&
+      filters.nearMeLon != null
+    );
+
   const countrySearchCode =
     cityInputCountry ||
     (!effectiveRawCity ? explicitCountry : '') ||
@@ -1424,7 +1444,11 @@ export async function fetchEvents({ locale = 'cs', filters = {} } = {}) {
       });
     }
   } else {
-    const broadCountry = countrySearchCode || explicitCountry || 'CZ';
+    const broadCountry =
+      allowGlobalKeywordSearch
+        ? ''
+        : countrySearchCode || explicitCountry || 'CZ';
+
     attempts.push({
       mode: 'broad',
       countryCode: broadCountry,

--- a/src/api/eventsApi.js
+++ b/src/api/eventsApi.js
@@ -751,13 +751,43 @@ export async function fetchEvents({ locale, filters = {} } = {}) {
     ? selectedCityCc
     : countryOnlyCc || explicitCountry || 'CZ';
 
+  // AJSEE_TM_GLOBAL_KEYWORD_DISCOVERY_v1
+  // A meaningful artist/event keyword without an active place filter should
+  // be discoverable across Ticketmaster markets. Keep the normal CZ/default
+  // country for local providers and for ordinary no-keyword discovery.
+  const normalizedKeyword = String(
+    filters.keyword ??
+    filters.q ??
+    filters.search ??
+    ''
+  ).trim();
+
+  const hasNearMeFilter =
+    nearMeLat != null &&
+    nearMeLon != null;
+
+  const hasExplicitPlaceFilter =
+    Boolean(upstreamCity) ||
+    Boolean(countryFromCityInput) ||
+    String(
+      filters.placeType ||
+      ''
+    )
+      .trim()
+      .toLowerCase() === 'country';
+
+  const shouldUseGlobalTicketmasterKeywordSearch =
+    normalizedKeyword.length >= 2 &&
+    !hasExplicitPlaceFilter &&
+    !hasNearMeFilter;
+
   const upstreamFilters = {
     ...filters,
     dateFrom: filters.dateFrom ?? filters.from ?? '',
     dateTo: filters.dateTo ?? filters.to ?? '',
     category: filters.category ?? filters.segment ?? 'all',
     audience: filters.audience ?? '',
-    keyword: filters.keyword ?? filters.q ?? filters.search ?? '',
+    keyword: normalizedKeyword,
     // KlĂ­ÄŤovĂˇ zmÄ›na:
     // pokud uĹľivatel zadal "Francie", neposĂ­lĂˇme to dĂˇl jako city.
     city: upstreamCity,
@@ -771,9 +801,21 @@ export async function fetchEvents({ locale, filters = {} } = {}) {
     city: localCityInput || upstreamCity
   };
 
+  const ticketmasterFilters =
+    shouldUseGlobalTicketmasterKeywordSearch
+      ? {
+          ...upstreamFilters,
+          countryCode: '',
+          globalKeywordSearch: true
+        }
+      : upstreamFilters;
+
 // --- Ticketmaster ---
 try {
-  const tm = await fetchTicketmasterEvents({ locale: loc, filters: upstreamFilters });
+  const tm = await fetchTicketmasterEvents({
+    locale: loc,
+    filters: ticketmasterFilters
+  });
 
   if (Array.isArray(tm)) {
     all = all.concat(tm);

--- a/src/api/eventsApi.js
+++ b/src/api/eventsApi.js
@@ -762,9 +762,11 @@ export async function fetchEvents({ locale, filters = {} } = {}) {
     ''
   ).trim();
 
+  // Use the input object here because the client-filter destructuring
+  // happens later in this function.
   const hasNearMeFilter =
-    nearMeLat != null &&
-    nearMeLon != null;
+    filters.nearMeLat != null &&
+    filters.nearMeLon != null;
 
   const hasExplicitPlaceFilter =
     Boolean(upstreamCity) ||

--- a/tests/ticketmaster-global-keyword-search.test.mjs
+++ b/tests/ticketmaster-global-keyword-search.test.mjs
@@ -102,7 +102,7 @@ test(
 
     assert.match(
       apiSource,
-      /nearMeLat != null[\s\S]*nearMeLon != null/
+      /const hasNearMeFilter =\s*filters\.nearMeLat != null &&\s*filters\.nearMeLon != null;/
     );
 
     assert.match(

--- a/tests/ticketmaster-global-keyword-search.test.mjs
+++ b/tests/ticketmaster-global-keyword-search.test.mjs
@@ -111,3 +111,22 @@ test(
     );
   }
 );
+test(
+  'global keyword discovery uses Ticketmaster wildcard locale',
+  () => {
+    assert.match(
+      tmSource,
+      /allowGlobalKeywordSearch\s*\?\s*\['\*'\]\s*:\s*makeLocaleList/
+    );
+  }
+);
+
+test(
+  'normal Ticketmaster discovery keeps the existing locale resolver',
+  () => {
+    assert.match(
+      tmSource,
+      /makeLocaleList\(\{[\s\S]*marketLocale,[\s\S]*locale,[\s\S]*countryCode:\s*targetCountryForLocale/
+    );
+  }
+);

--- a/tests/ticketmaster-global-keyword-search.test.mjs
+++ b/tests/ticketmaster-global-keyword-search.test.mjs
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const apiSource = fs.readFileSync(
+  new URL('../src/api/eventsApi.js', import.meta.url),
+  'utf8'
+);
+
+const tmSource = fs.readFileSync(
+  new URL('../src/adapters/ticketmaster.js', import.meta.url),
+  'utf8'
+);
+
+test(
+  'keyword-only discovery opts Ticketmaster into a global search',
+  () => {
+    assert.match(
+      apiSource,
+      /normalizedKeyword\.length >= 2[\s\S]*!hasExplicitPlaceFilter[\s\S]*!hasNearMeFilter/
+    );
+
+    assert.match(
+      apiSource,
+      /countryCode:\s*'',[\s\S]*globalKeywordSearch:\s*true/
+    );
+
+    assert.match(
+      apiSource,
+      /fetchTicketmasterEvents\(\{[\s\S]*filters:\s*ticketmasterFilters/
+    );
+  }
+);
+
+test(
+  'global keyword search is Ticketmaster-only',
+  () => {
+    assert.match(
+      apiSource,
+      /const localProviderFilters = \{[\s\S]*\.\.\.upstreamFilters/
+    );
+
+    assert.doesNotMatch(
+      apiSource,
+      /const localProviderFilters = \{[\s\S]*\.\.\.ticketmasterFilters/
+    );
+  }
+);
+
+test(
+  'Ticketmaster global search requires explicit upstream opt-in',
+  () => {
+    assert.match(
+      tmSource,
+      /filters\.globalKeywordSearch === true/
+    );
+
+    assert.match(
+      tmSource,
+      /globalKeyword\.length >= 2/
+    );
+
+    assert.match(
+      tmSource,
+      /!effectiveRawCity/
+    );
+  }
+);
+
+test(
+  'global keyword search removes country only from the opted-in broad attempt',
+  () => {
+    assert.match(
+      tmSource,
+      /allowGlobalKeywordSearch[\s\S]*\?\s*''[\s\S]*:\s*countrySearchCode \|\| explicitCountry \|\| 'CZ'/
+    );
+
+    assert.match(
+      tmSource,
+      /if \(!hasGeo && attempt\.countryCode\) qs\.set\('countryCode', attempt\.countryCode\)/
+    );
+  }
+);
+
+test(
+  'normal no-city Ticketmaster discovery keeps the CZ fallback',
+  () => {
+    assert.match(
+      tmSource,
+      /countrySearchCode \|\| explicitCountry \|\| 'CZ'/
+    );
+  }
+);
+
+test(
+  'city and Near Me guards remain part of global keyword eligibility',
+  () => {
+    assert.match(
+      apiSource,
+      /Boolean\(upstreamCity\)/
+    );
+
+    assert.match(
+      apiSource,
+      /nearMeLat != null[\s\S]*nearMeLon != null/
+    );
+
+    assert.match(
+      tmSource,
+      /filters\.nearMeLat != null[\s\S]*filters\.nearMeLon != null/
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Fixes Ticketmaster keyword-only discovery when no location is selected.

Previously, searches such as `thirty seconds to mars` without a city inherited the default `CZ` country context, so valid Ticketmaster events in other markets were not discoverable.

### Changes
- enables cross-market Ticketmaster discovery for meaningful keyword-only searches
- removes the implicit country restriction only for this specific Ticketmaster flow
- keeps local-provider filters unchanged
- preserves explicit city/country searches
- preserves Near Me behaviour
- preserves normal no-keyword CZ/default discovery
- preserves the existing CZ/SK city + keyword fallback logic

### Expected behaviour
- keyword + no location → cross-market Ticketmaster discovery
- city + keyword → existing city/country behaviour
- city without keyword → existing behaviour
- explicit country → existing country restriction
- Near Me → existing behaviour
- no keyword + no location → existing default-country discovery

### QA
- targeted regression suite: 74/74 PASS
- `git diff --check`: PASS
- working tree clean

### Runtime QA remaining
- keyword-only international discovery
- explicit foreign city + keyword regression
- Prague + keyword regression
- default `/events` regression
- explicit country + keyword regression