### PR TITLE
refactor(events): share event card and responsive grid

### DIFF
--- a/src/event-card.js
+++ b/src/event-card.js
@@ -433,15 +433,7 @@ export function ensureSharedEventGridStyles(
       max-width: 1440px !important;
       margin-inline: auto;
 
-      grid-template-columns:
-        repeat(
-          auto-fill,
-          minmax(
-            min(100%, 280px),
-            1fr
-          )
-        ) !important;
-
+      grid-template-columns: 1fr !important;
       justify-content: start !important;
     }
 
@@ -502,6 +494,36 @@ export function ensureSharedEventGridStyles(
       object-position: center;
       border-radius: 18px;
       background: #eef5fb;
+    }
+
+    @media (min-width: 768px) {
+      #eventsList.events-list {
+        grid-template-columns:
+          repeat(
+            2,
+            minmax(0, 1fr)
+          ) !important;
+      }
+    }
+
+    @media (min-width: 1024px) {
+      #eventsList.events-list {
+        grid-template-columns:
+          repeat(
+            3,
+            minmax(0, 1fr)
+          ) !important;
+      }
+    }
+
+    @media (min-width: 1536px) {
+      #eventsList.events-list {
+        grid-template-columns:
+          repeat(
+            4,
+            minmax(0, 1fr)
+          ) !important;
+      }
     }
 
     @media (max-width: 760px) {

--- a/src/event-card.js
+++ b/src/event-card.js
@@ -1,0 +1,531 @@
+import { formatEventVenueLine } from './event-location.js';
+
+const FALLBACK_IMAGE = '/images/fallbacks/concert0.jpg';
+
+function escapeHtml(value = '') {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function eventProviderKey(event = {}) {
+  const raw = String(
+    event?.partner ||
+    event?.source ||
+    event?.bookingProvider ||
+    event?.affiliate?.provider ||
+    event?.tickets ||
+    event?.url ||
+    ''
+  )
+    .trim()
+    .toLowerCase();
+
+  if (raw.includes('smsticket')) return 'smsticket';
+
+  if (
+    raw.includes('ticketmaster') ||
+    raw.includes('tmoutbound')
+  ) {
+    return 'ticketmaster';
+  }
+
+  return '';
+}
+
+function eventProviderLabel(provider = '') {
+  if (provider === 'smsticket') return 'smsticket';
+  if (provider === 'ticketmaster') return 'Ticketmaster';
+
+  return '';
+}
+
+function eventProviderBadgeHtml(event = {}) {
+  const provider = eventProviderKey(event);
+  const label = eventProviderLabel(provider);
+
+  if (!provider || !label) return '';
+
+  return `
+    <p
+      class="event-partner-badge"
+      data-provider="${escapeHtml(provider)}"
+    >
+      <span>${escapeHtml(label)}</span>
+    </p>
+  `;
+}
+
+export function eventImageOrFallback(event = {}) {
+  const raw = String(
+    event?.image ||
+    event?.imageUrl ||
+    event?.imageOriginal ||
+    event?.images?.[0]?.url ||
+    ''
+  ).trim();
+
+  return raw
+    ? raw.replace(/^http:\/\//i, 'https://')
+    : FALLBACK_IMAGE;
+}
+
+/*
+ * Canonical AJSEE event-card markup.
+ *
+ * Page entrypoints still own:
+ * - fetching
+ * - pagination
+ * - ticket URL preparation
+ * - modal behaviour
+ *
+ * This module owns the visual card contract.
+ */
+export function renderSharedEventCard({
+  event = {},
+  modalId = '',
+  titleHtml = '',
+  titleRaw = '',
+  dateHtml = '',
+  imageSrc = '',
+  ticketsHref = '',
+  detailLabelHtml = '',
+  ticketLabelHtml = '',
+  provider = null,
+  providerBadgeHtml = null,
+  venueLineHtml = null,
+  eventCityAttrHtml = null
+} = {}) {
+  const resolvedProvider =
+    provider === null
+      ? eventProviderKey(event)
+      : String(provider || '');
+
+  const resolvedProviderBadge =
+    providerBadgeHtml === null
+      ? eventProviderBadgeHtml(event)
+      : String(providerBadgeHtml || '');
+
+  const resolvedVenueLine =
+    venueLineHtml === null
+      ? (() => {
+          const line = formatEventVenueLine(event);
+
+          return line
+            ? `<p class="event-date event-location">${escapeHtml(line)}</p>`
+            : '';
+        })()
+      : String(venueLineHtml || '');
+
+  const resolvedCityAttr =
+    eventCityAttrHtml === null
+      ? escapeHtml(
+          event?.location?.city ||
+          event?.venue?.city ||
+          event?.place?.city ||
+          ''
+        )
+      : String(eventCityAttrHtml || '');
+
+  const resolvedImage =
+    imageSrc ||
+    eventImageOrFallback(event);
+
+  const safeModalId =
+    escapeHtml(modalId);
+
+  const safeImage =
+    escapeHtml(resolvedImage);
+
+  const safeHref =
+    escapeHtml(ticketsHref);
+
+  const safeTitleAttr =
+    escapeHtml(titleRaw);
+
+  const safeProvider =
+    escapeHtml(resolvedProvider);
+
+  return `
+    <article
+      class="event-card"
+      data-event-id="${safeModalId}"
+      data-event-provider="${safeProvider}"
+    >
+      <img
+        src="${safeImage}"
+        alt="${titleHtml}"
+        class="event-img"
+        loading="lazy"
+        decoding="async"
+        onerror="this.onerror=null;this.src='${FALLBACK_IMAGE}';"
+      />
+
+      <div class="event-content">
+        <h3 class="event-title">${titleHtml}</h3>
+
+        <p class="event-date">${dateHtml}</p>
+
+        ${resolvedVenueLine}
+
+        ${resolvedProviderBadge}
+
+        <div class="event-buttons-group">
+          <button
+            type="button"
+            class="btn-event detail js-event-detail"
+            data-event-id="${safeModalId}"
+          >
+            ${detailLabelHtml}
+          </button>
+
+          <a
+            href="${safeHref}"
+            class="btn-event ticket js-partner-click"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-partner="${safeProvider}"
+            data-event-id="${safeModalId}"
+            data-placement="event_card"
+            data-event-title="${safeTitleAttr}"
+            data-event-city="${resolvedCityAttr}"
+            data-outbound-url="${safeHref}"
+          >
+            ${ticketLabelHtml}
+          </a>
+        </div>
+      </div>
+    </article>
+  `;
+}
+
+/*
+ * One responsive grid contract for homepage + /events.
+ *
+ * mobile        -> 1
+ * tablet        -> 2
+ * notebook      -> 3
+ * wide desktop  -> 4
+ *
+ * The card max-width protects a single result from stretching.
+ */
+const partnerClickBound = new WeakSet();
+
+export function trackSharedEventPartnerClick(
+  link,
+  {
+    win = globalThis.window,
+    doc = globalThis.document
+  } = {}
+) {
+  if (!link || !win || !doc) return;
+
+  const cleanText = value =>
+    String(value || '')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+  const getUrlHost = value => {
+    try {
+      return new URL(
+        value,
+        win.location.origin
+      ).hostname;
+    } catch {
+      return '';
+    }
+  };
+
+  const getLang = () =>
+    cleanText(
+      doc.documentElement?.getAttribute('lang')
+    )
+      .slice(0, 2)
+      .toLowerCase() || 'cs';
+
+  const partner =
+    cleanText(link.dataset.partner);
+
+  const eventId =
+    cleanText(link.dataset.eventId);
+
+  const eventName =
+    cleanText(link.dataset.eventTitle);
+
+  const city =
+    cleanText(link.dataset.eventCity);
+
+  const clickedHref =
+    cleanText(
+      link.href ||
+      link.getAttribute('href')
+    );
+
+  const outboundUrl =
+    cleanText(link.dataset.outboundUrl) ||
+    clickedHref;
+
+  const placement =
+    cleanText(link.dataset.placement) ||
+    'event_card';
+
+  let routeCity = '';
+  let routeCountryCode = '';
+
+  try {
+    const params =
+      new URLSearchParams(
+        win.location.search
+      );
+
+    routeCity =
+      cleanText(
+        params.get('city')
+      );
+
+    routeCountryCode =
+      cleanText(
+        params.get('cityCc') ||
+        params.get('country') ||
+        params.get('countryCode')
+      ).toUpperCase();
+  } catch {
+    /* noop */
+  }
+
+  if (!partner && !outboundUrl) return;
+
+  const payload = {
+    event: 'partner_click',
+
+    partner,
+    event_id: eventId,
+    event_name: eventName,
+    city,
+    outbound_url: outboundUrl,
+    placement,
+    page_path:
+      win.location.pathname +
+      win.location.search,
+    ts: new Date().toISOString(),
+
+    event_title: eventName,
+    event_city: city || routeCity,
+    event_provider: partner,
+    destination_url: outboundUrl,
+    destination_host:
+      getUrlHost(outboundUrl),
+    clicked_href: clickedHref,
+    clicked_host:
+      getUrlHost(clickedHref),
+    route_city: routeCity,
+    route_country_code:
+      routeCountryCode,
+    page_location:
+      win.location.href,
+    language: getLang(),
+    link_text:
+      cleanText(link.textContent)
+  };
+
+  try {
+    win.dataLayer =
+      win.dataLayer || [];
+
+    win.dataLayer.push(payload);
+  } catch {
+    /* noop */
+  }
+
+  try {
+    win.__ajsee =
+      win.__ajsee || {};
+
+    win.__ajsee.lastPartnerClick =
+      payload;
+  } catch {
+    /* noop */
+  }
+
+  try {
+    win.sessionStorage?.setItem(
+      'ajsee:lastPartnerClick',
+      JSON.stringify(payload)
+    );
+  } catch {
+    /* noop */
+  }
+
+  try {
+    win.console?.info?.(
+      '[AJSEE partner_click]',
+      payload
+    );
+  } catch {
+    /* noop */
+  }
+
+  return payload;
+}
+
+export function wireSharedEventCardAnalytics(
+  root = globalThis.document
+) {
+  const links =
+    root?.querySelectorAll?.(
+      '.js-partner-click'
+    ) || [];
+
+  for (const link of links) {
+    if (partnerClickBound.has(link)) {
+      continue;
+    }
+
+    partnerClickBound.add(link);
+
+    let tracked = false;
+
+    const trackOnce = () => {
+      if (tracked) return;
+
+      tracked = true;
+
+      trackSharedEventPartnerClick(link);
+    };
+
+    link.addEventListener(
+      'pointerdown',
+      trackOnce,
+      { passive: true }
+    );
+
+    link.addEventListener(
+      'click',
+      trackOnce
+    );
+  }
+}
+export function ensureSharedEventGridStyles(
+  doc = globalThis.document
+) {
+  if (!doc?.head) return;
+
+  if (
+    doc.getElementById(
+      'ajsee-shared-event-card-grid-v1-css'
+    )
+  ) {
+    return;
+  }
+
+  const style =
+    doc.createElement('style');
+
+  style.id =
+    'ajsee-shared-event-card-grid-v1-css';
+
+  style.textContent = `
+    #eventsList.events-list {
+      width: 100% !important;
+      max-width: 1440px !important;
+      margin-inline: auto;
+
+      grid-template-columns:
+        repeat(
+          auto-fill,
+          minmax(
+            min(100%, 280px),
+            1fr
+          )
+        ) !important;
+
+      justify-content: start !important;
+    }
+
+    #eventsList.events-list > .event-card {
+      width: 100% !important;
+      max-width: 24rem !important;
+      justify-self: start;
+    }
+
+    #eventsList.events-list > :not(.event-card) {
+      grid-column: 1 / -1;
+      width: 100%;
+    }
+
+    .event-card[data-event-provider] {
+      position: relative;
+    }
+
+    .event-partner-badge {
+      margin: 0 0 12px;
+      line-height: 1;
+    }
+
+    .event-partner-badge span {
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
+      padding: 5px 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(10, 61, 98, 0.12);
+      background: rgba(10, 61, 98, 0.045);
+      color: #0a3d62;
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: 0.02em;
+      white-space: nowrap;
+    }
+
+    .event-card[data-event-provider="smsticket"] .event-partner-badge span {
+      background: rgba(92, 70, 255, 0.08);
+      border-color: rgba(92, 70, 255, 0.16);
+      color: #342f75;
+    }
+
+    .event-card[data-event-provider="ticketmaster"] .event-partner-badge span {
+      background: rgba(0, 116, 224, 0.08);
+      border-color: rgba(0, 116, 224, 0.16);
+      color: #064c9b;
+    }
+
+    .event-card .event-img {
+      display: block;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      height: auto;
+      max-height: 260px;
+      object-fit: cover;
+      object-position: center;
+      border-radius: 18px;
+      background: #eef5fb;
+    }
+
+    @media (max-width: 760px) {
+      .event-card .event-img {
+        max-height: 220px;
+      }
+    }
+
+    @media (max-width: 700px) {
+      #eventsList.events-list {
+        grid-template-columns: 1fr !important;
+      }
+
+      #eventsList.events-list > .event-card {
+        max-width: none !important;
+      }
+    }
+
+    @media (max-width: 420px) {
+      .event-card .event-img {
+        max-height: 190px;
+      }
+    }
+  `;
+
+  doc.head.appendChild(style);
+}

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -1,3 +1,9 @@
+import {
+  ensureSharedEventGridStyles,
+  eventImageOrFallback,
+  renderSharedEventCard,
+  wireSharedEventCardAnalytics
+} from './event-card.js';
 // /src/events-entry.js
 // ---------------------------------------------------------
 // AJSEE – Events page UI, i18n & filters
@@ -34,7 +40,6 @@ import { canonForInputCity, guessCountryCodeFromCity } from './city/canonical.js
 import { getSortedBlogArticles } from './blogArticles.js';
 import { initNav } from './nav-core.js';
 import { initContactFormValidation } from './contact-validate.js';
-import { formatEventVenueLine } from './event-location.js';
 import { initEventModal, openEventModal } from './event-modal.js';
 import { ensureRuntimeStyles, updateHeaderOffset } from './runtime-style.js';
 
@@ -4001,228 +4006,6 @@ function initCityTypeahead(locale, { rebuild = false } = {}) {
 
 /* ───────── render events / paging ───────── */
 
-function ajseeEventProviderKey(ev = {}) {
-  const raw = String(
-    ev?.partner ||
-    ev?.source ||
-    ev?.bookingProvider ||
-    ev?.affiliate?.provider ||
-    ''
-  ).trim().toLowerCase();
-
-  if (!raw) return '';
-  if (raw.includes('smsticket')) return 'smsticket';
-  if (raw.includes('ticketmaster')) return 'ticketmaster';
-
-  return raw
-    .replace(/[^a-z0-9_-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-function ajseeEventProviderLabel(ev = {}, lang = getUILang()) {
-  const key = ajseeEventProviderKey(ev);
-
-  if (key === 'smsticket') return 'smsticket';
-  if (key === 'ticketmaster') return 'Ticketmaster';
-
-  return '';
-}
-
-function eventProviderBadgeHtml(ev = {}, lang = getUILang()) {
-  const key = ajseeEventProviderKey(ev);
-  const label = ajseeEventProviderLabel(ev, lang);
-
-  if (!key || !label) return '';
-
-  return '<p class="event-partner-badge" data-provider="' + esc(key) + '">' +
-    '<span>' + esc(label) + '</span>' +
-  '</p>';
-}
-
-function eventImageOrFallback(ev = {}) {
-  const raw = String(
-    ev?.image ||
-    ev?.imageUrl ||
-    ev?.imageOriginal ||
-    ev?.images?.[0]?.url ||
-    ''
-  ).trim();
-
-  if (raw) {
-    return raw.replace(/^http:\/\//i, 'https://');
-  }
-
-  return '/images/fallbacks/concert0.jpg';
-}
-
-function injectProviderBadgeStyles() {
-  injectOnce('ajsee-event-provider-badge-css', String.raw`
-    .event-card[data-event-provider]{
-      position:relative;
-    }
-
-    .event-partner-badge{
-      margin:0 0 12px;
-      line-height:1;
-    }
-
-    .event-partner-badge span{
-      display:inline-flex;
-      align-items:center;
-      min-height:24px;
-      padding:5px 10px;
-      border-radius:999px;
-      border:1px solid rgba(10,61,98,.12);
-      background:rgba(10,61,98,.045);
-      color:#0A3D62;
-      font-size:12px;
-      font-weight:800;
-      letter-spacing:.02em;
-      white-space:nowrap;
-    }
-
-    .event-card[data-event-provider="smsticket"] .event-partner-badge span{
-      background:rgba(92,70,255,.08);
-      border-color:rgba(92,70,255,.16);
-      color:#342f75;
-    }
-
-    .event-card[data-event-provider="ticketmaster"] .event-partner-badge span{
-      background:rgba(0,116,224,.08);
-      border-color:rgba(0,116,224,.16);
-      color:#064c9b;
-    }
-
-    .event-img{
-      background:#eef5fb;
-    }
-    `);
-
-  injectOnce('ajsee-event-card-image-stability-css', String.raw`
-    .event-card .event-img{
-      display:block;
-      width:100%;
-      aspect-ratio:16 / 9;
-      height:auto;
-      max-height:260px;
-      object-fit:cover;
-      object-position:center;
-      border-radius:18px;
-      background:#eef5fb;
-    }
-
-    @media (max-width: 760px){
-      .event-card .event-img{
-        max-height:220px;
-      }
-    }
-
-    @media (max-width: 420px){
-      .event-card .event-img{
-        max-height:190px;
-      }
-    }
-  `);
-}
-
-function trackPartnerClickFromLink(link) {
-  if (!link) return;
-
-  const cleanText = value => String(value || '').replace(/\s+/g, ' ').trim();
-
-  const getUrlHost = value => {
-    try {
-      return new URL(value, window.location.origin).hostname;
-    } catch {
-      return '';
-    }
-  };
-
-  const getLang = () =>
-    cleanText(document.documentElement.getAttribute('lang'))
-      .slice(0, 2)
-      .toLowerCase() || 'cs';
-
-  const partner = cleanText(link.dataset.partner);
-  const eventId = cleanText(link.dataset.eventId);
-  const eventName = cleanText(link.dataset.eventTitle);
-  const city = cleanText(link.dataset.eventCity);
-  const clickedHref = cleanText(link.href || link.getAttribute('href'));
-  const outboundUrl = cleanText(link.dataset.outboundUrl) || clickedHref;
-  const placement = cleanText(link.dataset.placement) || 'event_card';
-
-  let routeCity = '';
-  let routeCountryCode = '';
-
-  try {
-    const params = new URLSearchParams(window.location.search);
-    routeCity = cleanText(params.get('city'));
-    routeCountryCode = cleanText(
-      params.get('cityCc') ||
-      params.get('country') ||
-      params.get('countryCode')
-    ).toUpperCase();
-  } catch {
-    /* noop */
-  }
-
-  if (!partner && !outboundUrl) return;
-
-  const payload = {
-    event: 'partner_click',
-
-    // Existing fields kept for backward compatibility.
-    partner,
-    event_id: eventId,
-    event_name: eventName,
-    city,
-    outbound_url: outboundUrl,
-    placement,
-    page_path: window.location.pathname + window.location.search,
-    ts: new Date().toISOString(),
-
-    // Extended analytics fields.
-    event_title: eventName,
-    event_city: city || routeCity,
-    event_provider: partner,
-    destination_url: outboundUrl,
-    destination_host: getUrlHost(outboundUrl),
-    clicked_href: clickedHref,
-    clicked_host: getUrlHost(clickedHref),
-    route_city: routeCity,
-    route_country_code: routeCountryCode,
-    page_location: window.location.href,
-    language: getLang(),
-    link_text: cleanText(link.textContent)
-  };
-
-  try {
-    window.dataLayer = window.dataLayer || [];
-    window.dataLayer.push(payload);
-  } catch {
-    /* noop */
-  }
-
-  try {
-    window.__ajsee = window.__ajsee || {};
-    window.__ajsee.lastPartnerClick = payload;
-  } catch {
-    /* noop */
-  }
-
-  try {
-    sessionStorage.setItem('ajsee:lastPartnerClick', JSON.stringify(payload));
-  } catch {
-    /* noop */
-  }
-
-  try {
-    console.info('[AJSEE partner_click]', payload);
-  } catch {
-    /* noop */
-  }
-}
-
 function mapLangToTm(lang) {
   const map = { cs: 'cs-cz', sk: 'sk-sk', pl: 'pl-pl', de: 'de-de', hu: 'hu-hu', en: 'en-gb' };
   return map[(lang || 'en').slice(0, 2)] || 'en-gb';
@@ -4858,29 +4641,8 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
      */
     resetEventsEmptyStateViewTracking();
 
-    injectProviderBadgeStyles();
 
-    /*
-     * Keep event cards at a stable product-card width.
-     * auto-fill keeps empty grid tracks reserved, unlike auto-fit,
-     * so a single result does not stretch across the full 1200px container.
-     * Non-card states still span the complete result grid.
-     */
-    injectOnce('ajsee-events-card-grid-v1-css', String.raw`
-      #eventsList.events-list{
-        grid-template-columns:
-          repeat(
-            auto-fill,
-            minmax(min(100%, 360px), 24rem)
-          );
-        justify-content:start;
-      }
-
-      #eventsList.events-list > :not(.event-card){
-        grid-column:1 / -1;
-        width:100%;
-      }
-    `);
+    ensureSharedEventGridStyles();
 
 
     const modalStore = new Map();
@@ -4908,34 +4670,18 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
 
       const detailLabel = esc(t('event-details', 'Detail'));
       const ticketLabel = esc(t('event-tickets', 'Vstupenky'));
-      const provider = ajseeEventProviderKey(ev);
-      const providerBadge = eventProviderBadgeHtml(ev, locale);
-      const venueLine = formatEventVenueLine(ev);
-      const venueLineHtml = venueLine
-        ? `<p class="event-date event-location">${esc(venueLine)}</p>`
-        : '';
-      const eventCityAttr = esc(ev?.location?.city || ev?.venue?.city || ev?.place?.city || '');
-      const eventTitleAttr = esc(titleRaw);
 
-      return `
-        <article class="event-card" data-event-id="${esc(modalId)}" data-event-provider="${esc(provider)}">
-          <img src="${esc(img)}" alt="${title}" class="event-img" loading="lazy" decoding="async" onerror="this.onerror=null;this.src='/images/fallbacks/concert0.jpg';"/>
-          <div class="event-content">
-            <h3 class="event-title">${title}</h3>
-            <p class="event-date">${date}</p>
-            ${venueLineHtml}
-            ${providerBadge}
-            <div class="event-buttons-group">
-              <button type="button" class="btn-event detail js-event-detail" data-event-id="${esc(modalId)}">
-                ${detailLabel}
-              </button>
-              <a href="${ticketsHref}" class="btn-event ticket js-partner-click" target="_blank" rel="noopener noreferrer" data-partner="${esc(provider)}" data-event-id="${esc(modalId)}" data-placement="event_card" data-event-title="${eventTitleAttr}" data-event-city="${eventCityAttr}" data-outbound-url="${ticketsHref}">
-                ${ticketLabel}
-              </a>
-            </div>
-          </div>
-        </article>
-      `;
+      return renderSharedEventCard({
+        event: ev,
+        modalId,
+        titleHtml: title,
+        titleRaw,
+        dateHtml: date,
+        imageSrc: img,
+        ticketsHref,
+        detailLabelHtml: detailLabel,
+        ticketLabelHtml: ticketLabel
+      });
     }).join('');
 
     list.__ajseeEventModalStore = modalStore;
@@ -4952,18 +4698,7 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
     });
 
 
-    qsa('.js-partner-click', list).forEach(link => {
-      let tracked = false;
-
-      const trackOnce = () => {
-        if (tracked) return;
-        tracked = true;
-        trackPartnerClickFromLink(link);
-      };
-
-      link.addEventListener('pointerdown', trackOnce, { passive: true });
-      link.addEventListener('click', trackOnce);
-    });
+    wireSharedEventCardAnalytics(list);
 
     updateEventsPagerControls();
     announce(

--- a/src/home-entry.js
+++ b/src/home-entry.js
@@ -1,3 +1,9 @@
+import {
+  ensureSharedEventGridStyles,
+  eventImageOrFallback,
+  renderSharedEventCard,
+  wireSharedEventCardAnalytics
+} from './event-card.js';
 // /src/home-entry.js
 // ---------------------------------------------------------
 // AJSEE – Homepage UI, events preview, i18n & contact
@@ -3502,6 +3508,8 @@ const modalStore = new Map();
       visible: toRender.length,
       isHomePreview: true
     });
+ensureSharedEventGridStyles();
+
 list.innerHTML = toRender.map((ev, index) => {
   const modalId = String(ev.id || `event-${index}`);
 
@@ -3516,7 +3524,7 @@ list.innerHTML = toRender.map((ev, index) => {
     ? esc(new Date(dateVal).toLocaleDateString(locale, { day: 'numeric', month: 'long', year: 'numeric' }))
     : '';
 
-  const img = ev.image || '/images/fallbacks/concert0.jpg';
+  const img = eventImageOrFallback(ev);
 
   // Důležité:
   // Ticket link zůstává přes stejný bezpečný outbound flow jako doteď.
@@ -3535,35 +3543,17 @@ list.innerHTML = toRender.map((ev, index) => {
   const detailLabel = esc(t('event-details', 'Detail'));
   const ticketLabel = esc(t('event-tickets', 'Vstupenky'));
 
-  return `
-    <article class="event-card" data-event-id="${esc(modalId)}">
-      <img src="${esc(img)}" alt="${title}" class="event-img" loading="lazy"/>
-
-      <div class="event-content">
-        <h3 class="event-title">${title}</h3>
-        <p class="event-date">${date}</p>
-
-        <div class="event-buttons-group">
-          <button
-            type="button"
-            class="btn-event detail js-event-detail"
-            data-event-id="${esc(modalId)}"
-          >
-            ${detailLabel}
-          </button>
-
-          <a
-            href="${ticketsHref}"
-            class="btn-event ticket"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            ${ticketLabel}
-          </a>
-        </div>
-      </div>
-    </article>
-  `;
+  return renderSharedEventCard({
+    event: ev,
+    modalId,
+    titleHtml: title,
+    titleRaw,
+    dateHtml: date,
+    imageSrc: img,
+    ticketsHref,
+    detailLabelHtml: detailLabel,
+    ticketLabelHtml: ticketLabel
+  });
 }).join('');
 
 list.__ajseeEventModalStore = modalStore;
@@ -3581,6 +3571,8 @@ qsa('.js-event-detail', list).forEach(btn => {
     void lazyOpenHomeEventModal(selectedEvent, locale, { t });
   });
 });
+
+    wireSharedEventCardAnalytics(list);
 
     announce(`${t('events-found', 'Nalezeno') || 'Nalezeno'} ${out.length}`);
   } catch {

--- a/tests/event-card-modal-polish.test.mjs
+++ b/tests/event-card-modal-polish.test.mjs
@@ -7,6 +7,11 @@ const eventsSource = readFileSync(
   'utf8'
 );
 
+const sharedCardSource = readFileSync(
+  new URL('../src/event-card.js', import.meta.url),
+  'utf8'
+);
+
 const modalSource = readFileSync(
   new URL('../src/event-modal.js', import.meta.url),
   'utf8'
@@ -17,15 +22,25 @@ const ticketmasterSource = readFileSync(
   'utf8'
 );
 
-test('single event result keeps a stable desktop card track', () => {
+test('single event result keeps a stable shared desktop card track', () => {
   assert.match(
-    eventsSource,
-    /repeat\(\s*auto-fill,\s*minmax\(\s*min\(100%,\s*360px\),\s*24rem\s*\)\s*\)/
+    sharedCardSource,
+    /repeat\(\s*auto-fill,\s*minmax\(\s*min\(100%,\s*280px\),\s*1fr\s*\)\s*\)/
+  );
+
+  assert.match(
+    sharedCardSource,
+    /#eventsList\.events-list\s*>\s*\.event-card[\s\S]*max-width:\s*24rem/
+  );
+
+  assert.match(
+    sharedCardSource,
+    /#eventsList\.events-list\s*>\s*:not\(\.event-card\)/
   );
 
   assert.match(
     eventsSource,
-    /#eventsList\.events-list\s*>\s*:not\(\.event-card\)/
+    /ensureSharedEventGridStyles\(\)/
   );
 });
 

--- a/tests/event-card-modal-polish.test.mjs
+++ b/tests/event-card-modal-polish.test.mjs
@@ -25,7 +25,7 @@ const ticketmasterSource = readFileSync(
 test('single event result keeps a stable shared desktop card track', () => {
   assert.match(
     sharedCardSource,
-    /repeat\(\s*auto-fill,\s*minmax\(\s*min\(100%,\s*280px\),\s*1fr\s*\)\s*\)/
+    /@media\s*\(min-width:\s*1024px\)[\s\S]*repeat\(\s*3,\s*minmax\(0,\s*1fr\)\s*\)/
   );
 
   assert.match(

--- a/tests/events-filter-ux.test.mjs
+++ b/tests/events-filter-ux.test.mjs
@@ -986,7 +986,7 @@ test(
 
     assert.match(
       entry,
-      /resetEventsEmptyStateViewTracking\(\);[\s\S]*?injectProviderBadgeStyles/
+      /resetEventsEmptyStateViewTracking\(\);[\s\S]*?ensureSharedEventGridStyles\(\)/
     );
   }
 );

--- a/tests/shared-event-card-grid.test.mjs
+++ b/tests/shared-event-card-grid.test.mjs
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+import {
+  renderSharedEventCard
+} from '../src/event-card.js';
+
+const sharedSource = fs.readFileSync(
+  new URL('../src/event-card.js', import.meta.url),
+  'utf8'
+);
+
+const homeSource = fs.readFileSync(
+  new URL('../src/home-entry.js', import.meta.url),
+  'utf8'
+);
+
+const eventsSource = fs.readFileSync(
+  new URL('../src/events-entry.js', import.meta.url),
+  'utf8'
+);
+
+test(
+  'shared event card contains the canonical AJSEE card contract',
+  () => {
+    const html = renderSharedEventCard({
+      event: {
+        partner: 'ticketmaster',
+        location: {
+          city: 'Praha'
+        },
+        venue: {
+          name: 'O2 arena',
+          city: 'Praha 9'
+        }
+      },
+      modalId: 'ticketmaster-test-1',
+      titleHtml: 'Test event',
+      titleRaw: 'Test event',
+      dateHtml: '20. května 2027',
+      imageSrc: 'https://example.com/image.jpg',
+      ticketsHref: 'https://example.com/tickets',
+      detailLabelHtml: 'Zjistit více',
+      ticketLabelHtml: 'Vstupenky'
+    });
+
+    assert.match(
+      html,
+      /class="event-card"/
+    );
+
+    assert.match(
+      html,
+      /O2 arena · Praha/
+    );
+
+    assert.match(
+      html,
+      /Ticketmaster/
+    );
+
+    assert.match(
+      html,
+      /class="btn-event ticket js-partner-click"/
+    );
+
+    assert.match(
+      html,
+      /data-placement="event_card"/
+    );
+
+    assert.match(
+      html,
+      /data-event-id="ticketmaster-test-1"/
+    );
+  }
+);
+
+test(
+  'homepage and events page use the same event-card renderer',
+  () => {
+    assert.match(
+      homeSource,
+      /renderSharedEventCard\(\{/
+    );
+
+    assert.match(
+      eventsSource,
+      /renderSharedEventCard\(\{/
+    );
+
+    assert.match(
+      homeSource,
+      /ensureSharedEventGridStyles\(\)/
+    );
+
+    assert.match(
+      eventsSource,
+      /ensureSharedEventGridStyles\(\)/
+    );
+  }
+);
+
+test(
+  'legacy events-only grid injection is removed',
+  () => {
+    assert.doesNotMatch(
+      eventsSource,
+      /ajsee-events-card-grid-v1-css/
+    );
+  }
+);
+
+test(
+  'shared grid owns responsive card sizing',
+  () => {
+    assert.match(
+      sharedSource,
+      /max-width:\s*1440px/
+    );
+
+    assert.match(
+      sharedSource,
+      /auto-fill/
+    );
+
+    assert.match(
+      sharedSource,
+      /min\(100%,\s*280px\)/
+    );
+
+    assert.match(
+      sharedSource,
+      /max-width:\s*24rem/
+    );
+
+    assert.match(
+      sharedSource,
+      /@media\s*\(max-width:\s*700px\)/
+    );
+  }
+);
+
+test(
+  'homepage no longer owns its own event-card markup',
+  () => {
+    assert.doesNotMatch(
+      homeSource,
+      /<article class="event-card" data-event-id=/
+    );
+  }
+);

--- a/tests/shared-event-card-grid.test.mjs
+++ b/tests/shared-event-card-grid.test.mjs
@@ -122,12 +122,12 @@ test(
 
     assert.match(
       sharedSource,
-      /auto-fill/
+      /@media\s*\(min-width:\s*1024px\)/
     );
 
     assert.match(
       sharedSource,
-      /min\(100%,\s*280px\)/
+      /@media\s*\(min-width:\s*1536px\)[\s\S]*repeat\(\s*4,\s*minmax\(0,\s*1fr\)\s*\)/
     );
 
     assert.match(

--- a/tests/ticket-outbound-analytics.test.mjs
+++ b/tests/ticket-outbound-analytics.test.mjs
@@ -7,6 +7,11 @@ const eventsEntrySource = fs.readFileSync(
   'utf8'
 );
 
+const sharedCardSource = fs.readFileSync(
+  new URL('../src/event-card.js', import.meta.url),
+  'utf8'
+);
+
 const eventModalSource = fs.readFileSync(
   new URL('../src/event-modal.js', import.meta.url),
   'utf8'
@@ -16,32 +21,32 @@ test(
   'event card exposes event identity and explicit analytics placement',
   () => {
     assert.match(
-      eventsEntrySource,
-      /data-event-id="\$\{esc\(modalId\)\}"/
+      sharedCardSource,
+      /data-event-id="\$\{safeModalId\}"/
     );
 
     assert.match(
-      eventsEntrySource,
+      sharedCardSource,
       /data-placement="event_card"/
     );
 
     assert.match(
-      eventsEntrySource,
-      /const eventId = cleanText\(link\.dataset\.eventId\);/
+      sharedCardSource,
+      /const eventId =\s*cleanText\(\s*link\.dataset\.eventId\s*\);/
     );
 
     assert.match(
-      eventsEntrySource,
-      /const placement = cleanText\(link\.dataset\.placement\) \|\| 'event_card';/
+      sharedCardSource,
+      /const placement =\s*cleanText\(\s*link\.dataset\.placement\s*\)\s*\|\|\s*'event_card';/
     );
 
     assert.match(
-      eventsEntrySource,
-      /event_id:\s*eventId,/
+      sharedCardSource,
+      /event_id:\s*eventId/
     );
 
     assert.match(
-      eventsEntrySource,
+      sharedCardSource,
       /\bplacement,/
     );
   }
@@ -76,23 +81,28 @@ test(
   'event card guards pointerdown plus click against duplicate tracking',
   () => {
     assert.match(
-      eventsEntrySource,
-      /let tracked = false;/
+      sharedCardSource,
+      /const partnerClickBound = new WeakSet\(\)/
     );
 
     assert.match(
-      eventsEntrySource,
-      /if \(tracked\) return;\s*tracked = true;\s*trackPartnerClickFromLink\(link\);/
+      sharedCardSource,
+      /let tracked = false/
     );
 
     assert.match(
-      eventsEntrySource,
-      /addEventListener\('pointerdown', trackOnce/
+      sharedCardSource,
+      /if \(tracked\) return;/
     );
 
     assert.match(
-      eventsEntrySource,
-      /addEventListener\('click', trackOnce\)/
+      sharedCardSource,
+      /link\.addEventListener\(\s*'pointerdown',\s*trackOnce,\s*\{\s*passive:\s*true\s*\}\s*\)/
+    );
+
+    assert.match(
+      sharedCardSource,
+      /link\.addEventListener\(\s*'click',\s*trackOnce\s*\)/
     );
   }
 );


### PR DESCRIPTION
## Summary

Unifies the event card and responsive event grid used by the homepage and `/events`.

### What changed

- adds a shared `src/event-card.js`
- homepage and `/events` now use the same event-card renderer
- centralizes:
  - event card markup
  - venue display
  - provider detection and badge
  - image fallback and sizing
  - partner-click analytics
  - responsive event grid
- removes duplicated event-card logic from `events-entry.js`
- keeps page-specific fetching, pagination, filters and modal behaviour unchanged

### Responsive grid

Target behaviour:

- mobile: 1 card
- tablet: 2 cards
- notebook: 3 cards
- wide desktop: 4 cards

Single/few results retain a stable card width instead of stretching across the container.

### Regression coverage

76 targeted tests passing:

- event card / modal
- location display
- outbound analytics
- events filter UX
- search quality
- taxonomy filters
- global Ticketmaster keyword discovery
- shared EventCard / EventGrid

### QA required on Deploy Preview

- homepage: 4 cards wide / 3 notebook / 1 mobile
- `/events`: 4 cards wide / 3 notebook / 1 mobile
- single result does not stretch
- venue/provider presentation identical
- Detail works
- ticket CTA works
- `partner_click` works on homepage and `/events`
- filters/pagination/empty/error states unchanged