### PR TITLE
fix(home): center mobile event filters

### DIFF
--- a/src/styles/partials/events.scss
+++ b/src/styles/partials/events.scss
@@ -1359,7 +1359,7 @@ body[data-page="home"] .section-events .home-announcements > .hp-banner {
 
 @media (max-width: 600px) {
   body[data-page="home"] .section-events > .container {
-    padding-inline: 16px;
+    padding-inline: 0;
   }
 
   body[data-page="home"] .section-events {


### PR DESCRIPTION
Fixes mobile homepage event-filter alignment by removing the redundant inner container padding below 600px.

No filter behavior changes.
Build and 103 tests pass.