### PR TITLE
feat(site): add automatic dark mode and resilient event fallback

### DIFF
--- a/about.html
+++ b/about.html
@@ -494,7 +494,7 @@
 
           <defs>
             <style>
-              :root{ --bg1:#eaf6ff; --bg2:#dff1ff; --glow:rgba(47,147,255,.18); --path:#2a7cff; --accent:#00c2ff; --ring:#49bfff; --dot:#1288d6; }
+              :root{ --bg1:var(--aj-about-route-bg-1, #eaf6ff); --bg2:var(--aj-about-route-bg-2, #dff1ff); --glow:rgba(47,147,255,.18); --path:#2a7cff; --accent:#00c2ff; --ring:#49bfff; --dot:#1288d6; }
               #route-glow{ stroke:var(--glow); stroke-width:14; fill:none; stroke-linecap:round; stroke-dasharray:1; stroke-dashoffset:1; animation:draw 4.2s ease-in-out forwards .3s; filter:url(#blur); }
               #route{ stroke:var(--path); stroke-width:6; fill:none; stroke-linecap:round; stroke-linejoin:round; animation:draw 4.2s ease-in-out forwards .3s; filter:url(#soft-glow); }
               #arrow g{ filter:url(#lift); }
@@ -510,7 +510,7 @@
               @keyframes pulse{ 0%{transform:scale(1);opacity:.7} 70%,100%{transform:scale(2.15);opacity:0} }
             </style>
 
-            <radialGradient id="bg" cx="35%" cy="20%" r="115%"><stop offset="0%" stop-color="#ffffff"/><stop offset="60%" stop-color="var(--bg2)"/><stop offset="100%" stop-color="var(--bg1)"/></radialGradient>
+            <radialGradient id="bg" cx="35%" cy="20%" r="115%"><stop offset="0%" stop-color="var(--aj-about-route-bg-start, #ffffff)"/><stop offset="60%" stop-color="var(--bg2)"/><stop offset="100%" stop-color="var(--bg1)"/></radialGradient>
             <filter id="blur" x="-20%" y="-20%" width="140%" height="140%"><feGaussianBlur stdDeviation="7"/></filter>
             <filter id="soft-glow" x="-30%" y="-30%" width="160%"><feGaussianBlur stdDeviation="1.6" result="g"/><feMerge><feMergeNode in="g"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
             <filter id="lift" x="-20%" y="-20%" width="140%"><feDropShadow dx="0" dy="1.5" stdDeviation="2.5" flood-opacity=".35"/></filter>

--- a/coming-soon/thanks.html
+++ b/coming-soon/thanks.html
@@ -33,6 +33,8 @@
       --muted:#5c6a7a;
       --border:#d9e1ea;
       --brand:#0077cc;
+      --card:#ffffff;
+      --button-hover:#0063a8;
     }
     * { box-sizing: border-box; }
     body {
@@ -42,7 +44,7 @@
       color: var(--text);
     }
     .wrap { max-width: 720px; margin: 0 auto; padding: 64px 20px; }
-    .card { background: #fff; border: 1px solid var(--border); border-radius: 16px; padding: 32px; }
+    .card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; padding: 32px; }
     h1 { margin: 0 0 8px; }
     p { color: var(--muted); margin: 0; }
     a.btn {
@@ -56,7 +58,29 @@
       font-weight: 600;
     }
     a.btn:hover,
-    a.btn:focus { background: #0063a8; color: #fff; }
+    a.btn:focus { background: var(--button-hover); color: #fff; }
+
+    /* AJSEE_UTILITY_DARK_COMING_SOON_THANKS_V1 */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #09131f;
+        --text: #f3f7fb;
+        --muted: #b3c2d2;
+        --border: rgba(255, 255, 255, 0.12);
+        --brand: #0b74e5;
+        --card: #101c2a;
+        --button-hover: #085ab5;
+      }
+
+      .card {
+        box-shadow: 0 18px 50px rgba(0, 0, 0, 0.28);
+      }
+
+      a.btn:focus-visible {
+        outline: 3px solid rgba(114, 197, 255, 0.46);
+        outline-offset: 4px;
+      }
+    }
   </style>
 </head>
 <body>

--- a/public/404.html
+++ b/public/404.html
@@ -19,7 +19,7 @@
 
   <style>
     :root {
-      color-scheme: light;
+      color-scheme: light dark;
 
       --page-background: #eef8ff;
       --page-highlight: #c8f7f9;
@@ -325,6 +325,73 @@
       color: var(--accent-dark);
       font-weight: 700;
       text-underline-offset: 0.2em;
+    }
+
+    /* AJSEE_UTILITY_DARK_404_V1 */
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --page-background: #09131f;
+        --page-highlight: #12313b;
+
+        --surface: rgba(16, 28, 42, 0.96);
+        --surface-border: rgba(255, 255, 255, 0.12);
+
+        --text-strong: #f3f7fb;
+        --text-body: #c3d0dc;
+        --text-muted: #9eafc1;
+
+        --accent: #20c8cf;
+        --accent-dark: #72d7dc;
+        --accent-soft: rgba(20, 194, 197, 0.14);
+
+        --shadow:
+          0 1.5rem 4rem rgba(0, 0, 0, 0.36);
+      }
+
+      body {
+        background:
+          radial-gradient(
+            circle at 12% 8%,
+            rgba(20, 194, 197, 0.13),
+            transparent 24rem
+          ),
+          radial-gradient(
+            circle at 92% 92%,
+            rgba(73, 159, 226, 0.12),
+            transparent 26rem
+          ),
+          linear-gradient(
+            145deg,
+            #0c1825 0%,
+            var(--page-background) 52%,
+            var(--page-highlight) 130%
+          );
+      }
+
+      .brand-logo {
+        padding: 0.15rem;
+        border-radius: 0.5rem;
+        background: #bff4f7;
+      }
+
+      .skip-link {
+        background: #172535;
+        color: var(--text-strong);
+      }
+
+      .eyebrow {
+        border-color: rgba(114, 215, 220, 0.28);
+      }
+
+      .button-secondary {
+        border-color: rgba(114, 215, 220, 0.3);
+        background: #101c2a;
+        color: #b8f4f5;
+      }
+
+      .button-secondary:hover {
+        background: var(--accent-soft);
+      }
     }
 
     @media (max-width: 36rem) {

--- a/src/api/eventsApi.js
+++ b/src/api/eventsApi.js
@@ -824,12 +824,25 @@ try {
   }
 } catch (e) {
   if (isRateLimitError(e)) {
-    e.code = e.code || 'TICKETMASTER_RATE_LIMITED';
-    e.partner = e.partner || 'ticketmaster';
-    throw e;
+    /*
+     * AJSEE_PROVIDER_ISOLATION_v1
+     *
+     * Ticketmaster rate limiting must not abort the whole aggregation.
+     * The Ticketmaster adapter already exposes its cooldown state, so the UI
+     * can still show a rate-limit message when no other provider has results.
+     *
+     * Continue here so SMS Ticket and any other independent providers can
+     * still return usable events.
+     */
+    if (isDev) {
+      console.warn(
+        '[eventsApi] Ticketmaster is rate limited; continuing with other providers.',
+        e
+      );
+    }
+  } else {
+    console.warn('[eventsApi] Ticketmaster fetch failed:', e);
   }
-
-  console.warn('[eventsApi] Ticketmaster fetch failed:', e);
 }
 
 

--- a/src/event-card.js
+++ b/src/event-card.js
@@ -463,9 +463,9 @@ export function ensureSharedEventGridStyles(
       min-height: 24px;
       padding: 5px 10px;
       border-radius: 999px;
-      border: 1px solid rgba(10, 61, 98, 0.12);
-      background: rgba(10, 61, 98, 0.045);
-      color: #0a3d62;
+      border: 1px solid var(--aj-provider-badge-border, rgba(10, 61, 98, 0.12));
+      background: var(--aj-provider-badge-bg, rgba(10, 61, 98, 0.045));
+      color: var(--aj-provider-badge-text, #0a3d62);
       font-size: 12px;
       font-weight: 800;
       letter-spacing: 0.02em;
@@ -473,15 +473,15 @@ export function ensureSharedEventGridStyles(
     }
 
     .event-card[data-event-provider="smsticket"] .event-partner-badge span {
-      background: rgba(92, 70, 255, 0.08);
-      border-color: rgba(92, 70, 255, 0.16);
-      color: #342f75;
+      background: var(--aj-provider-smsticket-bg, rgba(92, 70, 255, 0.08));
+      border-color: var(--aj-provider-smsticket-border, rgba(92, 70, 255, 0.16));
+      color: var(--aj-provider-smsticket-text, #342f75);
     }
 
     .event-card[data-event-provider="ticketmaster"] .event-partner-badge span {
-      background: rgba(0, 116, 224, 0.08);
-      border-color: rgba(0, 116, 224, 0.16);
-      color: #064c9b;
+      background: var(--aj-provider-ticketmaster-bg, rgba(0, 116, 224, 0.08));
+      border-color: var(--aj-provider-ticketmaster-border, rgba(0, 116, 224, 0.16));
+      color: var(--aj-provider-ticketmaster-text, #064c9b);
     }
 
     .event-card .event-img {

--- a/src/event-modal.js
+++ b/src/event-modal.js
@@ -468,10 +468,10 @@ function ensureModalStyles() {
       overflow: visible !important;
       display: grid;
       grid-template-columns: minmax(260px, 42%) 1fr;
-      background: rgba(255, 255, 255, 0.98);
-      border: 1px solid rgba(217, 225, 239, 0.95);
+      background: var(--aj-modal-bg, rgba(255, 255, 255, 0.98));
+      border: 1px solid var(--aj-modal-border, rgba(217, 225, 239, 0.95));
       border-radius: 28px;
-      box-shadow: 0 28px 80px rgba(9, 30, 66, 0.28);
+      box-shadow: var(--aj-modal-shadow, 0 28px 80px rgba(9, 30, 66, 0.28));
       margin: auto 0;
     }
 
@@ -484,8 +484,8 @@ function ensureModalStyles() {
       height: 42px;
       border: 0;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.92);
-      color: #14213d;
+      background: var(--aj-modal-close-bg, rgba(255, 255, 255, 0.92));
+      color: var(--aj-modal-close-text, #14213d);
       cursor: pointer;
       display: inline-flex;
       align-items: center;
@@ -498,7 +498,7 @@ function ensureModalStyles() {
       height: 100%;
       min-height: 420px;
       object-fit: cover;
-      background: #eef5ff;
+      background: var(--aj-modal-image-bg, #eef5ff);
       border-radius: 28px 0 0 28px;
     }
 
@@ -512,26 +512,26 @@ function ensureModalStyles() {
       font-size: clamp(28px, 4vw, 44px);
       line-height: 1.05;
       letter-spacing: -0.04em;
-      color: #102033;
+      color: var(--aj-modal-title, #102033);
     }
 
     .modal-meta {
       margin: 0 0 18px;
-      color: #526071;
+      color: var(--aj-modal-meta, #526071);
       font-weight: 650;
       line-height: 1.5;
     }
 
     .modal-description {
       margin: 0 0 18px;
-      color: #344054;
+      color: var(--aj-modal-description, #344054);
       line-height: 1.65;
       font-size: 16px;
     }
 
     .modal-category {
       margin: 0 0 22px;
-      color: #667085;
+      color: var(--aj-modal-category, #667085);
       font-size: 14px;
       font-weight: 700;
     }
@@ -558,7 +558,7 @@ function ensureModalStyles() {
     .calendar-label {
       display: block;
       margin-bottom: 10px;
-      color: #0A3D62;
+      color: var(--aj-modal-control-text, #0A3D62);
       font-size: 18px;
       font-weight: 800;
     }
@@ -576,9 +576,9 @@ function ensureModalStyles() {
       min-height: 40px;
       padding: 0 14px;
       border-radius: 999px;
-      border: 1px solid #d9e1ef;
-      background: #fff;
-      color: #14213d;
+      border: 1px solid var(--aj-modal-control-border, #d9e1ef);
+      background: var(--aj-modal-control-bg, #fff);
+      color: var(--aj-modal-control-text, #14213d);
       text-decoration: none;
       font-size: 14px;
       font-weight: 700;
@@ -999,7 +999,7 @@ function ensureModalConversionPolishStyles() {
 
     .event-modal .modal-category{
       margin-bottom:16px;
-      color:#667085;
+      color:var(--aj-modal-category, #667085);
       font-size:13px;
       font-style:normal !important;
       font-weight:700;
@@ -1007,7 +1007,7 @@ function ensureModalConversionPolishStyles() {
 
     .event-modal .modal-seller-note{
       margin:10px 0 20px;
-      color:#667085;
+      color:var(--aj-modal-secondary, #667085);
       font-size:13px;
       line-height:1.45;
       font-weight:600;
@@ -1019,7 +1019,7 @@ function ensureModalConversionPolishStyles() {
 
     .event-modal .calendar-label{
       margin-bottom:8px;
-      color:#526071;
+      color:var(--aj-modal-meta, #526071);
       font-size:14px;
       font-weight:750;
     }
@@ -1039,10 +1039,10 @@ function ensureModalConversionPolishStyles() {
       min-width:0 !important;
       min-height:38px !important;
       padding:0 12px !important;
-      border:1px solid rgba(10,61,98,.18) !important;
+      border:1px solid var(--aj-modal-control-border, rgba(10,61,98,.18)) !important;
       border-radius:10px !important;
-      background:#fff !important;
-      color:#0A3D62 !important;
+      background:var(--aj-modal-control-bg, #fff) !important;
+      color:var(--aj-modal-control-text, #0A3D62) !important;
       box-shadow:none !important;
       font-size:14px !important;
       font-weight:750 !important;
@@ -1052,8 +1052,8 @@ function ensureModalConversionPolishStyles() {
     .event-modal .calendar-btn:hover,
     .event-modal .ajsee-modal-calendar-actions-v1 > a:hover,
     .event-modal .ajsee-modal-calendar-actions-v1 > button:hover{
-      border-color:rgba(10,61,98,.32) !important;
-      background:#f5f9fd !important;
+      border-color:var(--aj-modal-control-border-hover, rgba(10,61,98,.32)) !important;
+      background:var(--aj-modal-control-hover, #f5f9fd) !important;
     }
 
     .event-modal .calendar-btn:focus-visible{

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -4438,11 +4438,11 @@ function updateEventsPagerControls() {
 
   injectOnce('ajsee-events-pager-css', String.raw`
     .events-pager{ display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; margin:28px auto 0; text-align:center; }
-    .events-pager__status{ flex:0 0 100%; font-size:14px; color:#667085; margin-bottom:2px; }
-    .events-pager__btn{ border:1px solid rgba(10,61,98,.16); background:#fff; color:#0A3D62; border-radius:999px; padding:11px 18px; min-height:44px; font-weight:800; cursor:pointer; box-shadow:0 8px 20px rgba(9,30,66,.06); transition:transform .16s ease, box-shadow .16s ease, opacity .16s ease; }
-    .events-pager__btn:hover:not(:disabled){ transform:translateY(-1px); box-shadow:0 12px 28px rgba(9,30,66,.10); }
+    .events-pager__status{ flex:0 0 100%; font-size:14px; color:var(--aj-pager-status, #667085); margin-bottom:2px; }
+    .events-pager__btn{ border:1px solid var(--aj-pager-button-border, rgba(10,61,98,.16)); background:var(--aj-pager-button-bg, #fff); color:var(--aj-pager-button-text, #0A3D62); border-radius:999px; padding:11px 18px; min-height:44px; font-weight:800; cursor:pointer; box-shadow:var(--aj-pager-button-shadow, 0 8px 20px rgba(9,30,66,.06)); transition:transform .16s ease, box-shadow .16s ease, opacity .16s ease; }
+    .events-pager__btn:hover:not(:disabled){ transform:translateY(-1px); box-shadow:var(--aj-pager-button-shadow-hover, 0 12px 28px rgba(9,30,66,.10)); }
     .events-pager__btn:disabled{ opacity:.45; cursor:not-allowed; box-shadow:none; }
-    .events-pager__btn--primary{ background:#0A3D62; color:#fff; border-color:#0A3D62; }
+    .events-pager__btn--primary{ background:var(--aj-pager-primary-bg, #0A3D62); color:var(--aj-pager-primary-text, #fff); border-color:var(--aj-pager-primary-border, #0A3D62); }
   `);
 
   const host = ensureEventsPagerHost();
@@ -4570,11 +4570,13 @@ async function renderEvents(locale = 'cs', filters = currentFilters) {
       _lastFetchSig = '';
     }
 
-    if (eventsPager.buffer.length === 0 && isTicketmasterRateLimited()) {
-      renderEventsStateMessage('rateLimit');
-      return;
-    }
-
+    /*
+     * AJSEE_PROVIDER_ISOLATION_v1
+     *
+     * Do not short-circuit the whole event aggregation just because
+     * Ticketmaster is currently rate limited. getAllEvents() can still
+     * return results from independent providers such as SMS Ticket.
+     */
     await ensureEventsPageLoaded(locale, api, pagination.page);
 
     if (eventsPager.buffer.length === 0 && isTicketmasterRateLimited()) {
@@ -5151,9 +5153,9 @@ if (!G.flags.mainDomReadyBound) {
         min-height:24px;
         padding:5px 10px;
         border-radius:999px;
-        border:1px solid rgba(10,61,98,.12);
-        background:rgba(10,61,98,.045);
-        color:#0A3D62;
+        border:1px solid var(--aj-provider-badge-border, rgba(10,61,98,.12));
+        background:var(--aj-provider-badge-bg, rgba(10,61,98,.045));
+        color:var(--aj-provider-badge-text, #0A3D62);
         font-size:12px;
         font-weight:800;
         letter-spacing:.02em;
@@ -5162,16 +5164,16 @@ if (!G.flags.mainDomReadyBound) {
 
       #eventsList .event-card[data-event-provider="smsticket"] .event-partner-badge span,
       .events-list .event-card[data-event-provider="smsticket"] .event-partner-badge span{
-        background:rgba(92,70,255,.08);
-        border-color:rgba(92,70,255,.16);
-        color:#342f75;
+        background:var(--aj-provider-smsticket-bg, rgba(92,70,255,.08));
+        border-color:var(--aj-provider-smsticket-border, rgba(92,70,255,.16));
+        color:var(--aj-provider-smsticket-text, #342f75);
       }
 
       #eventsList .event-card[data-event-provider="ticketmaster"] .event-partner-badge span,
       .events-list .event-card[data-event-provider="ticketmaster"] .event-partner-badge span{
-        background:rgba(0,116,224,.08);
-        border-color:rgba(0,116,224,.16);
-        color:#064c9b;
+        background:var(--aj-provider-ticketmaster-bg, rgba(0,116,224,.08));
+        border-color:var(--aj-provider-ticketmaster-border, rgba(0,116,224,.16));
+        color:var(--aj-provider-ticketmaster-text, #064c9b);
       }
     `;
 

--- a/src/home-entry.js
+++ b/src/home-entry.js
@@ -4774,9 +4774,9 @@ if (!G.flags.mainDomReadyBound) {
         min-height:24px;
         padding:5px 10px;
         border-radius:999px;
-        border:1px solid rgba(92,70,255,.16);
-        background:rgba(92,70,255,.08);
-        color:#342f75;
+        border:1px solid var(--aj-provider-smsticket-border, rgba(92,70,255,.16));
+        background:var(--aj-provider-smsticket-bg, rgba(92,70,255,.08));
+        color:var(--aj-provider-smsticket-text, #342f75);
         font-size:12px;
         font-weight:800;
         letter-spacing:.02em;

--- a/src/main.js
+++ b/src/main.js
@@ -3533,9 +3533,9 @@ function injectProviderBadgeStyles() {
       min-height:24px;
       padding:5px 10px;
       border-radius:999px;
-      border:1px solid rgba(10,61,98,.12);
-      background:rgba(10,61,98,.045);
-      color:#0A3D62;
+      border:1px solid var(--aj-provider-badge-border, rgba(10,61,98,.12));
+      background:var(--aj-provider-badge-bg, rgba(10,61,98,.045));
+      color:var(--aj-provider-badge-text, #0A3D62);
       font-size:12px;
       font-weight:800;
       letter-spacing:.02em;
@@ -3543,15 +3543,15 @@ function injectProviderBadgeStyles() {
     }
 
     .event-card[data-event-provider="smsticket"] .event-partner-badge span{
-      background:rgba(92,70,255,.08);
-      border-color:rgba(92,70,255,.16);
-      color:#342f75;
+      background:var(--aj-provider-smsticket-bg, rgba(92,70,255,.08));
+      border-color:var(--aj-provider-smsticket-border, rgba(92,70,255,.16));
+      color:var(--aj-provider-smsticket-text, #342f75);
     }
 
     .event-card[data-event-provider="ticketmaster"] .event-partner-badge span{
-      background:rgba(0,116,224,.08);
-      border-color:rgba(0,116,224,.16);
-      color:#064c9b;
+      background:var(--aj-provider-ticketmaster-bg, rgba(0,116,224,.08));
+      border-color:var(--aj-provider-ticketmaster-border, rgba(0,116,224,.16));
+      color:var(--aj-provider-ticketmaster-text, #064c9b);
     }
 
     .event-img{
@@ -4663,9 +4663,9 @@ if (!G.flags.mainDomReadyBound) {
         min-height:24px;
         padding:5px 10px;
         border-radius:999px;
-        border:1px solid rgba(10,61,98,.12);
-        background:rgba(10,61,98,.045);
-        color:#0A3D62;
+        border:1px solid var(--aj-provider-badge-border, rgba(10,61,98,.12));
+        background:var(--aj-provider-badge-bg, rgba(10,61,98,.045));
+        color:var(--aj-provider-badge-text, #0A3D62);
         font-size:12px;
         font-weight:800;
         letter-spacing:.02em;
@@ -4674,16 +4674,16 @@ if (!G.flags.mainDomReadyBound) {
 
       #eventsList .event-card[data-event-provider="smsticket"] .event-partner-badge span,
       .events-list .event-card[data-event-provider="smsticket"] .event-partner-badge span{
-        background:rgba(92,70,255,.08);
-        border-color:rgba(92,70,255,.16);
-        color:#342f75;
+        background:var(--aj-provider-smsticket-bg, rgba(92,70,255,.08));
+        border-color:var(--aj-provider-smsticket-border, rgba(92,70,255,.16));
+        color:var(--aj-provider-smsticket-text, #342f75);
       }
 
       #eventsList .event-card[data-event-provider="ticketmaster"] .event-partner-badge span,
       .events-list .event-card[data-event-provider="ticketmaster"] .event-partner-badge span{
-        background:rgba(0,116,224,.08);
-        border-color:rgba(0,116,224,.16);
-        color:#064c9b;
+        background:var(--aj-provider-ticketmaster-bg, rgba(0,116,224,.08));
+        border-color:var(--aj-provider-ticketmaster-border, rgba(0,116,224,.16));
+        color:var(--aj-provider-ticketmaster-text, #064c9b);
       }
     `;
 

--- a/src/styles/pages/about-page.scss
+++ b/src/styles/pages/about-page.scss
@@ -1,10 +1,11 @@
-﻿// ------------------------------------------------------
+// ------------------------------------------------------
 // AJSEE – About page SCSS entry point
 // ------------------------------------------------------
 // Cíl: netahat na About stránku celý globální main.scss bundle.
 // Obsahuje pouze společné UI + styly potřebné pro about.html.
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';

--- a/src/styles/pages/accommodation.scss
+++ b/src/styles/pages/accommodation.scss
@@ -11,6 +11,7 @@
 */
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';

--- a/src/styles/pages/blog-detail-page.scss
+++ b/src/styles/pages/blog-detail-page.scss
@@ -5,6 +5,7 @@
 // Obsahuje pouze společné UI + styly potřebné pro blog detail a komentáře.
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';
@@ -52,6 +53,14 @@ body {
   line-height: 1;
   letter-spacing: 0.02em;
   white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  body[data-page="review-detail"] .review-content-type-badge {
+    border-color: rgba(89, 223, 226, 0.34);
+    background: rgba(20, 194, 197, 0.13);
+    color: #7ce7e9;
+  }
 }
 
 .review-meta-row {

--- a/src/styles/pages/blog-page.scss
+++ b/src/styles/pages/blog-page.scss
@@ -4,6 +4,7 @@
 // ------------------------------------------------------
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';

--- a/src/styles/pages/cookies-policy.scss
+++ b/src/styles/pages/cookies-policy.scss
@@ -1,4 +1,5 @@
 @use '../globals' as *;
+@use '../utils/theme';
 
 
 

--- a/src/styles/pages/events-page.scss
+++ b/src/styles/pages/events-page.scss
@@ -3,6 +3,7 @@
 // ------------------------------------------------------
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';
@@ -17,6 +18,7 @@
 @use '../partials/cookie-consent';
 @use '../partials/tablet-responsive-fix';
 @use '../partials/filters-parity-final';
+@use '../partials/theme-event-shell';
 
 // Page-level globals previously provided by main.scss
 html,

--- a/src/styles/pages/faq-page.scss
+++ b/src/styles/pages/faq-page.scss
@@ -5,6 +5,7 @@
 // Obsahuje pouze společné UI + styly potřebné pro FAQ.
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';

--- a/src/styles/pages/home-deferred.scss
+++ b/src/styles/pages/home-deferred.scss
@@ -9,3 +9,4 @@
 @use '../partials/blog';
 @use '../partials/contact';
 @use '../partials/footer';
+@use '../partials/theme-home-deferred';

--- a/src/styles/pages/home-page.scss
+++ b/src/styles/pages/home-page.scss
@@ -3,6 +3,7 @@
 // ------------------------------------------------------
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';
@@ -15,6 +16,7 @@
 @use '../partials/waitlist-banner';
 @use '../partials/tablet-responsive-fix';
 @use '../partials/filters-parity-final';
+@use '../partials/theme-event-shell';
 @use '../partials/cookie-consent';
 
 // Page-level globals previously provided by main.scss
@@ -121,9 +123,7 @@ body[data-page="home"] .hp-banner--london-musicals {
   position: relative;
   overflow: hidden;
   border-color: rgba(20, 194, 197, 0.34);
-  background:
-    radial-gradient(circle at 12% 24%, rgba(20, 194, 197, 0.18), transparent 16rem),
-    linear-gradient(135deg, rgba(234, 252, 255, 0.96), rgba(247, 252, 255, 0.92));
+  background: var(--aj-home-promo-bg);
   box-shadow: 0 22px 60px rgba(10, 54, 82, 0.12);
 }
 
@@ -137,7 +137,7 @@ body[data-page="home"] .hp-banner--london-musicals::after {
 }
 
 body[data-page="home"] .hp-banner--london-musicals .hp-banner__icon {
-  background: linear-gradient(135deg, #eafcff, #d6f7fb);
+  background: var(--aj-home-promo-icon-bg);
   border-color: rgba(20, 194, 197, 0.3);
 }
 
@@ -145,11 +145,11 @@ body[data-page="home"] .hp-banner--london-musicals .hp-banner__title {
   font-size: clamp(1.35rem, 2.1vw, 1.85rem);
   line-height: 1.12;
   letter-spacing: -0.035em;
-  color: #06192b;
+  color: var(--aj-home-promo-title);
 }
 
 body[data-page="home"] .hp-banner--london-musicals .hp-banner__body {
-  color: rgba(16, 32, 51, 0.72);
+  color: var(--aj-home-promo-body);
 }
 
 body[data-page="home"] .hp-banner--london-musicals .hp-banner__cta {
@@ -163,8 +163,8 @@ body[data-page="home"] .hp-banner--london-musicals .hp-banner__cta {
 
 /* Keep other homepage banners calmer so the London musicals card is visually first. */
 body[data-page="home"] .event-demo-badge.hp-banner:not(.hp-banner--london-musicals) {
-  background: rgba(255, 255, 255, 0.68);
-  border-color: rgba(14, 107, 168, 0.16);
+  background: var(--aj-home-muted-banner-bg);
+  border-color: var(--aj-home-muted-banner-border);
 }
 
 @media (max-width: 720px) {

--- a/src/styles/pages/microguides-page.scss
+++ b/src/styles/pages/microguides-page.scss
@@ -5,6 +5,7 @@
 // Obsahuje pouze společné UI + styly potřebné pro microguides detail/listing.
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';

--- a/src/styles/pages/partners-page.scss
+++ b/src/styles/pages/partners-page.scss
@@ -1,10 +1,11 @@
-﻿// ------------------------------------------------------
+// ------------------------------------------------------
 // AJSEE – Partners page SCSS entry point
 // ------------------------------------------------------
 // Cíl: netahat na Partners stránku celý globální main.scss bundle.
 // Obsahuje pouze společné UI + styly potřebné pro partners.html.
 
 @use '../globals' as *;
+@use '../utils/theme';
 @use '../utils/reset';
 
 @use '../partials/layout';
@@ -13,6 +14,7 @@
 
 @use '../partials/partners';
 @use '../partials/contact';
+@use '../partials/theme-partners';
 
 @use '../partials/cookie-consent';
 

--- a/src/styles/pages/privacy-policy.scss
+++ b/src/styles/pages/privacy-policy.scss
@@ -1,4 +1,5 @@
 @use '../globals' as *;
+@use '../utils/theme';
 
 
 

--- a/src/styles/partials/_coming-soon.scss
+++ b/src/styles/partials/_coming-soon.scss
@@ -101,3 +101,64 @@
     }
   }
 }
+
+/* AJSEE_UTILITY_DARK_COMING_SOON_V1 */
+@media (prefers-color-scheme: dark) {
+  .comingsoon-page {
+    --bg: #09131f;
+    --card: #101c2a;
+    --ink: #f3f7fb;
+    --muted: #b3c2d2;
+    --accent: #0b74e5;
+    --accent2: #2788ee;
+    --ring: rgba(85, 185, 255, 0.34);
+
+    .brand img {
+      background: #bff4f7;
+      border-radius: 8px;
+    }
+
+    .card {
+      border-color: rgba(255, 255, 255, 0.12);
+      box-shadow: 0 18px 50px rgba(0, 0, 0, 0.32);
+    }
+
+    form {
+      input[type="email"] {
+        background: #0c1825;
+        border-color: rgba(255, 255, 255, 0.16);
+        color: var(--ink);
+
+        &::placeholder {
+          color: #8295a8;
+          opacity: 1;
+        }
+
+        &:hover {
+          border-color: rgba(114, 197, 255, 0.42);
+        }
+
+        &:focus {
+          border-color: #72c5ff;
+        }
+      }
+
+      input[type="checkbox"] {
+        accent-color: var(--accent);
+      }
+    }
+
+    .btn-back {
+      background: #101c2a;
+      border-color: rgba(255, 255, 255, 0.14);
+      color: #8fd4ff;
+
+      &:hover,
+      &:focus-visible {
+        background: #162638;
+        border-color: rgba(114, 197, 255, 0.5);
+        color: #c5eaff;
+      }
+    }
+  }
+}

--- a/src/styles/partials/_comments.scss
+++ b/src/styles/partials/_comments.scss
@@ -6,6 +6,8 @@
   --comments-primary: #0077cc;
   --comments-primary-hover: #005fa3;
   --comments-navy: #22223b;
+  --comments-control: #ffffff;
+  --comments-item: #ffffff;
 
   margin-top: clamp(2.5rem, 6vw, 4.5rem);
   padding-top: clamp(2rem, 5vw, 3.5rem);
@@ -69,7 +71,7 @@
     padding: 0.8rem 0.9rem;
     border: 1px solid var(--comments-border-strong);
     border-radius: 0.65rem;
-    background: #ffffff;
+    background: var(--comments-control);
     color: var(--comments-navy);
     font: inherit;
     line-height: 1.5;
@@ -163,7 +165,7 @@
     padding: 1.15rem 1.25rem;
     border: 1px solid var(--comments-border);
     border-radius: 0.85rem;
-    background: #ffffff;
+    background: var(--comments-item);
   }
 
   &__item-header {
@@ -210,7 +212,7 @@
     padding: 0.55rem 0.85rem;
     border: 1px solid var(--comments-primary);
     border-radius: 0.55rem;
-    background: #ffffff;
+    background: var(--comments-control);
     color: var(--comments-primary);
     font: inherit;
     font-weight: 700;
@@ -253,5 +255,40 @@
     &__submit:hover:not(:disabled) {
       transform: none;
     }
+  }
+}
+/* AJSEE COMMENTS DARK V1 */
+@media (prefers-color-scheme: dark) {
+  .article-comments {
+    --comments-border: rgba(255, 255, 255, 0.12);
+    --comments-border-strong: rgba(255, 255, 255, 0.18);
+    --comments-muted: #9eafc1;
+    --comments-surface: #132131;
+    --comments-primary: #55b9ff;
+    --comments-primary-hover: #72c5ff;
+    --comments-navy: #f3f7fb;
+    --comments-control: #172535;
+    --comments-item: #101c2a;
+  }
+
+  .article-comments__field input:hover,
+  .article-comments__field textarea:hover {
+    border-color: rgba(85, 185, 255, 0.52);
+  }
+
+  .article-comments__field input:focus,
+  .article-comments__field textarea:focus {
+    box-shadow: 0 0 0 3px rgba(85, 185, 255, 0.16);
+  }
+
+  .article-comments__field input:focus-visible,
+  .article-comments__field textarea:focus-visible,
+  .article-comments__submit:focus-visible,
+  .article-comments__error button:focus-visible {
+    outline-color: rgba(85, 185, 255, 0.46);
+  }
+
+  .article-comments__error button:hover {
+    background: rgba(85, 185, 255, 0.09);
   }
 }

--- a/src/styles/partials/_date-popover.scss
+++ b/src/styles/partials/_date-popover.scss
@@ -8,19 +8,16 @@
   --ajsee-date-panel-z: calc(var(--ajsee-popover-z, 10040) + 1);
   --ajsee-date-panel-backdrop-z: var(--ajsee-popover-overlay-z, 10030);
 
-  --ajsee-date-panel-bg: rgba(255, 255, 255, 0.98);
-  --ajsee-date-panel-brd: rgba(207, 220, 235, 0.95);
-  --ajsee-date-panel-shadow:
-    0 24px 48px rgba(12, 36, 80, 0.16),
-    0 4px 14px rgba(12, 36, 80, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  --ajsee-date-panel-bg: var(--aj-date-panel-bg);
+  --ajsee-date-panel-brd: var(--aj-date-panel-border);
+  --ajsee-date-panel-shadow: var(--aj-date-panel-shadow);
 
   --ajsee-date-panel-radius: 24px;
-  --ajsee-date-ink: #102840;
-  --ajsee-date-ink-soft: #6b7f97;
+  --ajsee-date-ink: var(--aj-date-text);
+  --ajsee-date-ink-soft: var(--aj-date-text-soft);
   --ajsee-date-accent: #0e88f0;
   --ajsee-date-accent-strong: #2b63db;
-  --ajsee-date-border-soft: rgba(226, 235, 245, 0.96);
+  --ajsee-date-border-soft: var(--aj-date-border-soft);
 
   --ajsee-date-desktop-width: 640px;
   --ajsee-date-desktop-cell: 40px;
@@ -30,18 +27,6 @@
   --ajsee-date-mobile-gap: 8px;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --ajsee-date-panel-bg: rgba(14, 22, 35, 0.96);
-    --ajsee-date-panel-brd: rgba(255, 255, 255, 0.12);
-    --ajsee-date-panel-shadow:
-      0 30px 60px rgba(0, 0, 0, 0.45),
-      inset 0 1px 0 rgba(255, 255, 255, 0.06);
-    --ajsee-date-ink: #eef4ff;
-    --ajsee-date-ink-soft: #aebed3;
-    --ajsee-date-border-soft: rgba(255, 255, 255, 0.1);
-  }
-}
 
 body.ajsee-date-sheet-open {
   position: fixed;
@@ -85,7 +70,7 @@ body.ajsee-date-sheet-open {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0) 24%);
+  background: var(--aj-date-sheen);
   pointer-events: none;
   z-index: 0;
 }

--- a/src/styles/partials/_filters-parity-final.scss
+++ b/src/styles/partials/_filters-parity-final.scss
@@ -67,7 +67,7 @@ html body[data-page="events"] main#main section#upcoming-events.events-upcoming-
   --events-filter-radius: clamp(22px, 2vw, 28px);
   --events-filter-control-h: 76px;
 
-  background: #fff;
+  background: var(--aj-page-bg, #fff);
 }
 
 html body[data-page="events"] main#main section#upcoming-events.events-upcoming-section > .container {
@@ -91,7 +91,7 @@ html body[data-page="events"] main#main section#upcoming-events.events-upcoming-
   line-height: 1.02;
   font-weight: 900;
   letter-spacing: -0.04em;
-  color: #0d2235;
+  color: var(--aj-text-strong, #0d2235);
   text-shadow: 0 10px 30px rgba(12, 36, 80, 0.08);
 }
 
@@ -133,13 +133,10 @@ html body:is([data-page="home"], [data-page="events"]) form#events-filters-form.
   margin: 0 auto clamp(1.45rem, 2vw, 1.9rem);
   padding: clamp(16px, 1.3vw, 18px) clamp(18px, 1.6vw, 22px);
 
-  border: 1px solid rgba(224, 235, 245, 0.92);
+  border: 1px solid var(--aj-filter-panel-border);
   border-radius: var(--events-filter-radius);
-  background: linear-gradient(180deg, rgba(248, 252, 255, 0.98) 0%, rgba(242, 248, 253, 0.96) 100%);
-  box-shadow:
-    0 20px 44px rgba(12, 36, 80, 0.08),
-    0 2px 10px rgba(12, 36, 80, 0.04),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  background: var(--aj-filter-panel-bg);
+  box-shadow: var(--aj-filter-panel-shadow);
 }
 
 html body:is([data-page="home"], [data-page="events"]) form#events-filters-form.events-filters.filter-dock::before {
@@ -220,7 +217,7 @@ html body:is([data-page="home"], [data-page="events"]) form#events-filters-form.
   font-weight: 900;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #456a8f;
+  color: var(--aj-filter-label-text);
   opacity: 0.98;
 }
 
@@ -253,20 +250,16 @@ html body:is([data-page="home"], [data-page="events"]) form#events-filters-form.
   font-size: clamp(1rem, 0.98vw, 1.08rem);
   font-weight: 800;
   line-height: 1.15;
-  color: #173a62;
+  color: var(--aj-filter-control-text);
 
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(250, 253, 255, 0.98)) padding-box,
-    linear-gradient(135deg, #dfeaf7, #edf4fb) border-box;
+  background: var(--aj-filter-control-surface);
   border: 1.25px solid transparent;
-  box-shadow:
-    0 12px 24px rgba(12, 36, 80, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  box-shadow: var(--aj-filter-control-shadow);
 }
 
 html body:is([data-page="home"], [data-page="events"]) form#events-filters-form.events-filters.filter-dock input.styled-input::placeholder {
   font-weight: 600;
-  color: #7e93ac;
+  color: var(--aj-filter-control-muted);
   opacity: 1;
 }
 
@@ -570,7 +563,7 @@ body[data-page="events"] .events-filter-summary__top {
 
 body[data-page="events"] .events-results-count {
   margin: 0;
-  color: #173a62;
+  color: var(--aj-filter-summary-text);
   font-size: clamp(1rem, 1.2vw, 1.12rem);
   font-weight: 900;
 }
@@ -581,19 +574,19 @@ body[data-page="events"] .events-filter-summary__clear {
   border: 0;
   border-radius: 999px;
   background: transparent;
-  color: #0b5ed7;
+  color: var(--aj-filter-summary-clear);
   font: inherit;
   font-weight: 850;
   cursor: pointer;
 }
 
 body[data-page="events"] .events-filter-summary__clear:hover {
-  background: rgba(14, 136, 240, 0.08);
+  background: var(--aj-filter-summary-clear-hover);
 }
 
 body[data-page="events"] .events-filter-summary__clear:focus-visible,
 body[data-page="events"] .events-filter-chip:focus-visible {
-  outline: 3px solid rgba(14, 136, 240, 0.28);
+  outline: 3px solid var(--aj-filter-focus-outline);
   outline-offset: 3px;
 }
 
@@ -614,10 +607,10 @@ body[data-page="events"] .events-filter-chip {
   gap: 0.55rem;
   min-height: 42px;
   padding: 0.62rem 0.82rem 0.62rem 0.95rem;
-  border: 1px solid rgba(14, 136, 240, 0.2);
+  border: 1px solid var(--aj-filter-summary-chip-border);
   border-radius: 999px;
-  background: linear-gradient(180deg, #ffffff, #f4f9ff);
-  color: #173a62;
+  background: var(--aj-filter-summary-chip-bg);
+  color: var(--aj-filter-summary-chip-text);
   font: inherit;
   font-size: 0.92rem;
   font-weight: 800;
@@ -626,8 +619,8 @@ body[data-page="events"] .events-filter-chip {
 }
 
 body[data-page="events"] .events-filter-chip:hover {
-  border-color: rgba(14, 136, 240, 0.38);
-  background: #eef7ff;
+  border-color: var(--aj-filter-summary-chip-border-hover);
+  background: var(--aj-filter-summary-chip-hover);
 }
 
 body[data-page="events"] .events-filter-chip__remove {
@@ -637,7 +630,7 @@ body[data-page="events"] .events-filter-chip__remove {
   width: 22px;
   height: 22px;
   border-radius: 999px;
-  background: rgba(14, 136, 240, 0.1);
+  background: var(--aj-filter-summary-chip-remove-bg);
   font-size: 1.05rem;
   line-height: 1;
 }

--- a/src/styles/partials/_microguides.scss
+++ b/src/styles/partials/_microguides.scss
@@ -482,6 +482,508 @@
 }
 
 /* ——— PRINT CSS (minimal) ——— */
+
+/* AJSEE MICROGUIDES DARK V1 */
+@media (prefers-color-scheme: dark) {
+
+  body[data-page="microguides"] {
+    background: var(--aj-page-bg);
+    color: var(--aj-text);
+  }
+
+  body[data-page="microguides"] main.mg {
+    background: var(--aj-page-bg);
+    color: var(--aj-text);
+  }
+
+
+  /* -------------------------------------------------------
+     Index
+     Current index markup has no dedicated base CSS owner.
+     These rules are dark-only so Light Mode stays untouched.
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg-index {
+    color: var(--aj-text);
+  }
+
+  body[data-page="microguides"] .mg-index-hero {
+    color: var(--aj-text);
+  }
+
+  body[data-page="microguides"] .mg-index-hero .mg-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"] .mg-index-hero .mg-kicker {
+    color: #59dfe2;
+  }
+
+  body[data-page="microguides"] .mg-index-hero .mg-lead {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"] .mg-index .mg-card {
+    background: var(--aj-surface);
+    border-color: var(--aj-border);
+    color: var(--aj-text);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="microguides"] .mg-index .mg-card:hover,
+  body[data-page="microguides"] .mg-index .mg-card:focus-within {
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-border-strong);
+    box-shadow: var(--aj-card-shadow-hover);
+  }
+
+  body[data-page="microguides"] .mg-index .mg-card-link {
+    color: inherit;
+  }
+
+  body[data-page="microguides"] .mg-index .mg-card-link h2,
+  body[data-page="microguides"] .mg-index .mg-card-body h2 {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"] .mg-index .mg-card-link p,
+  body[data-page="microguides"] .mg-index .mg-card-body p {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"] .mg-index .mg-card-media {
+    background: var(--aj-media-placeholder);
+  }
+
+  body[data-page="microguides"] .mg-empty {
+    color: var(--aj-text-secondary);
+  }
+
+
+  /* -------------------------------------------------------
+     Breadcrumb
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg .mg-breadcrumb {
+    color: var(--aj-text-muted);
+    border-bottom-color: var(--aj-border);
+    background:
+      linear-gradient(
+        180deg,
+        var(--aj-surface) 0%,
+        var(--aj-surface) 60%,
+        var(--aj-surface-soft) 100%
+      );
+  }
+
+  body[data-page="microguides"] .mg .mg-breadcrumb a {
+    color: #72c5ff;
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-breadcrumb
+  a:focus-visible {
+    outline-color: var(--aj-focus);
+  }
+
+
+  /* -------------------------------------------------------
+     Detail hero
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg .mg-hero {
+    color: var(--aj-text);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-hero
+  .mg-kicker {
+    color: #59dfe2;
+    opacity: 1;
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-hero
+  .mg-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-hero
+  .mg-meta {
+    color: var(--aj-text-secondary);
+    opacity: 1;
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-hero
+  .btn-share {
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-border-strong);
+    color: var(--aj-text-strong);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-hero
+  .btn-share:hover {
+    background: var(--aj-surface-hover);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-hero
+  .btn-share:focus-visible {
+    outline-color: var(--aj-focus);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-hero-media {
+    box-shadow: var(--aj-card-shadow);
+  }
+
+
+  /* -------------------------------------------------------
+     Sticky progress / TOC
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg .mg-progress {
+    background: rgba(16, 28, 42, 0.9);
+    border-color: var(--aj-border);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-progress
+  ol
+  a {
+    background: var(--aj-soft-control-bg);
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-progress
+  ol
+  a:hover {
+    background: var(--aj-soft-control-hover);
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-progress
+  ol
+  a:focus-visible {
+    outline-color: var(--aj-focus);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-progress
+  ol
+  a[aria-current="true"] {
+    background: #173c57;
+    color: #8bd0ff;
+    box-shadow: 0 0 0 2px rgba(85, 185, 255, 0.2) inset;
+  }
+
+
+  /* -------------------------------------------------------
+     Article content
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg .mg-section {
+    border-top-color: var(--aj-border);
+    color: var(--aj-text);
+  }
+
+  body[data-page="microguides"] .mg .mg-section h2 {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"] .mg .mg-section p {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"] .mg .mg-section li,
+  body[data-page="microguides"] .mg .mg-section strong,
+  body[data-page="microguides"] .mg .mg-section em {
+    color: inherit;
+  }
+
+  body[data-page="microguides"] .mg .mg-section a {
+    color: #72c5ff;
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-section
+  blockquote {
+    background: var(--aj-surface-soft);
+    border-left-color: #59dfe2;
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-section
+  blockquote
+  p {
+    color: inherit;
+  }
+
+
+  /* -------------------------------------------------------
+     Figures
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"]
+  .mg
+  .mg-section
+  .mg-media-frame {
+    /*
+     Transparent guide illustrations are authored for a light canvas.
+     Keep that neutral canvas in Dark Mode so diagrams/icons remain legible.
+    */
+    background: #f5f8fb;
+    border-color: rgba(255, 255, 255, 0.14);
+    box-shadow:
+      0 10px 28px rgba(0, 0, 0, 0.28),
+      inset 0 0 0 1px rgba(16, 40, 63, 0.05);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-section
+  .mg-figure
+  figcaption {
+    color: var(--aj-text-muted);
+  }
+
+
+  /* -------------------------------------------------------
+     Callouts
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg .mg-callout {
+    background: var(--aj-surface-soft);
+    border-color: var(--aj-border);
+    box-shadow: var(--aj-card-shadow);
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"] .mg .mg-callout p {
+    color: inherit;
+  }
+
+  body[data-page="microguides"] .mg .mg-callout strong {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"] .mg .mg-callout.-info {
+    background: #10283a;
+    border-color: rgba(85, 185, 255, 0.24);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-callout.-info
+  .callout-label {
+    color: #72c5ff;
+  }
+
+  body[data-page="microguides"] .mg .mg-callout.-tip {
+    background: #102c25;
+    border-color: rgba(95, 211, 160, 0.25);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-callout.-tip
+  .callout-label {
+    color: #9ee7c6;
+  }
+
+  body[data-page="microguides"] .mg .mg-callout.-warn {
+    background: #332719;
+    border-color: rgba(255, 190, 92, 0.28);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-callout.-warn
+  .callout-label {
+    color: #ffd08a;
+  }
+
+
+  /* -------------------------------------------------------
+     Footer CTA
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg .mg-footer-cta {
+    border-top-color: var(--aj-border-strong);
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-footer-cta
+  .ib-cta {
+    color: #59dfe2;
+  }
+
+
+  /* -------------------------------------------------------
+     Share
+     Runtime injects its own button surfaces later.
+     We only provide inherited text/focus colors here.
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg-share {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="microguides"]
+  .mg-share__btn:focus-visible {
+    outline: 2px solid var(--aj-focus);
+    outline-offset: 3px;
+  }
+
+
+  /* -------------------------------------------------------
+     Related guides
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg-related {
+    color: var(--aj-text);
+  }
+
+  body[data-page="microguides"]
+  .mg-related
+  .mg-related__title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"]
+  .mg-related
+  .mg-card {
+    background: var(--aj-surface);
+    border-color: var(--aj-border);
+    color: var(--aj-text);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="microguides"]
+  .mg-related
+  .mg-card:hover {
+    background: var(--aj-surface-elevated);
+    box-shadow: var(--aj-card-shadow-hover);
+  }
+
+  body[data-page="microguides"]
+  .mg-related
+  .mg-card
+  .mg-card__media {
+    background: var(--aj-media-placeholder);
+  }
+
+  body[data-page="microguides"]
+  .mg-related
+  .mg-card
+  .mg-card__title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"]
+  .mg-related
+  .mg-card
+  .mg-card__sum {
+    color: var(--aj-text-secondary);
+    opacity: 1;
+  }
+
+  body[data-page="microguides"]
+  .mg-related
+  .mg-card
+  .mg-card__cta {
+    color: #72c5ff;
+  }
+
+
+  /* -------------------------------------------------------
+     Mobile navigation
+  ------------------------------------------------------- */
+
+  body[data-page="microguides"] .mg .mg-mobile-nav {
+    background: rgba(16, 28, 42, 0.94);
+    border-top-color: var(--aj-border);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-prev,
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-next {
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-border-strong);
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-prev:hover,
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-next:hover {
+    background: var(--aj-surface-hover);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-prev:focus-visible,
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-next:focus-visible,
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-dot:focus-visible {
+    outline-color: var(--aj-focus);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-dot {
+    border-color: var(--aj-border-strong);
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  body[data-page="microguides"]
+  .mg
+  .mg-mobile-nav
+  .mg-dot[data-active="true"] {
+    background: #55b9ff;
+    border-color: #55b9ff;
+  }
+}
 @media print {
   .site-header, .site-footer,
   .mg-progress, .mg-mobile-nav,

--- a/src/styles/partials/_theme-event-shell.scss
+++ b/src/styles/partials/_theme-event-shell.scss
@@ -1,0 +1,371 @@
+// =========================================================
+// AJSEE THEME SYSTEM V1
+// Dark compatibility adapter for the event experience.
+// Light mode remains owned by the existing component CSS.
+// Scoped to homepage and events.
+// =========================================================
+
+
+@media (prefers-color-scheme: dark) {
+  html body:is([data-page="home"], [data-page="events"]) {
+    background: var(--aj-page-bg);
+    color: var(--aj-text);
+  }
+
+  /* =======================================================
+     HOMEPAGE — EVENT EXPERIENCE
+  ======================================================= */
+
+  body[data-page="home"] .section-events {
+    background: var(--aj-page-bg);
+  }
+
+  body[data-page="home"] .section-events .events-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"] .section-events .events-subtitle {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="home"] .hp-banner--london-musicals {
+    background: var(--aj-home-promo-bg);
+    border-color: rgba(20, 194, 197, 0.34);
+    box-shadow: 0 22px 60px rgba(0, 0, 0, 0.24);
+  }
+
+  body[data-page="home"]
+  .hp-banner--london-musicals
+  .hp-banner__icon {
+    background: var(--aj-home-promo-icon-bg);
+    border-color: rgba(91, 218, 221, 0.24);
+  }
+
+  body[data-page="home"]
+  .hp-banner--london-musicals
+  .hp-banner__title {
+    color: var(--aj-home-promo-title);
+  }
+
+  body[data-page="home"]
+  .hp-banner--london-musicals
+  .hp-banner__body {
+    color: var(--aj-home-promo-body);
+  }
+
+  body[data-page="home"]
+  .event-demo-badge.hp-banner:not(.hp-banner--london-musicals) {
+    background: rgba(18, 34, 49, 0.88);
+    border-color: var(--aj-border);
+  }
+
+
+  /* =======================================================
+     EVENTS PAGE
+  ======================================================= */
+
+  body[data-page="events"] main#main {
+    background: var(--aj-page-bg);
+  }
+
+  body[data-page="events"] .events-hero {
+    background: var(--aj-events-hero-bg);
+  }
+
+  body[data-page="events"] .events-hero .events-hero-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="events"] .events-hero .events-hero-desc {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="events"] .events-upcoming-section {
+    background: var(--aj-page-bg);
+  }
+
+  html body[data-page="events"]
+  main#main
+  #upcoming-events.events-upcoming-section,
+  html body[data-page="events"]
+  main#main
+  #upcoming-events.events-upcoming-section > .container {
+    background: var(--aj-page-bg);
+  }
+
+  body[data-page="events"]
+  #events-filters-form
+  #chipClear {
+    background: var(--aj-soft-control-bg);
+    border-color: var(--aj-border);
+    color: var(--aj-text-muted);
+  }
+
+  body[data-page="events"]
+  #events-filters-form
+  #chipClear:hover:not(:disabled) {
+    background: var(--aj-soft-control-hover);
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="events"]
+  #events-filters-form
+  #chipClear:focus-visible {
+    outline: 3px solid var(--aj-focus);
+    outline-offset: 3px;
+  }
+
+  body[data-page="events"] .events-upcoming-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="events"] .events-categories {
+    background: var(--aj-surface);
+  }
+
+  body[data-page="events"] .events-categories h3,
+  body[data-page="events"] .events-benefits h3 {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="events"] .events-categories .category-card {
+    background: var(--aj-surface-elevated);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="events"] .events-categories .category-card:hover,
+  body[data-page="events"] .events-categories .category-card:focus,
+  body[data-page="events"]
+  .events-categories
+  .category-card[aria-pressed="true"] {
+    background: var(--aj-surface-hover);
+    box-shadow: var(--aj-card-shadow-hover);
+  }
+
+  body[data-page="events"] .events-categories .category-card span {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="events"] .events-benefits {
+    background: var(--aj-surface-soft);
+  }
+
+  body[data-page="events"] .events-benefits .benefit {
+    background: var(--aj-surface-elevated);
+    color: var(--aj-text-strong);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+
+  /* =======================================================
+     SHARED EVENT CARDS
+  ======================================================= */
+
+  body:is([data-page="home"], [data-page="events"]) .event-card {
+    background: var(--aj-surface-elevated);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body:is([data-page="home"], [data-page="events"]) .event-card:hover {
+    box-shadow: var(--aj-card-shadow-hover);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .event-card
+  .event-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"] .event-card .event-date {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="events"] .event-card .event-date {
+    color: #72c5ff;
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .event-card
+  .event-description {
+    color: var(--aj-text-secondary);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .event-card
+  .event-img {
+    background: var(--aj-media-placeholder);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .btn-event.demo {
+    background: var(--aj-soft-control-bg);
+    color: var(--aj-text-secondary);
+    border-color: var(--aj-border-strong);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .btn-event.demo:hover {
+    background: var(--aj-soft-control-hover);
+  }
+
+
+  /* =======================================================
+     HOMEPAGE FILTER RESULT STATES
+  ======================================================= */
+
+  body[data-page="home"]
+  #events-filters-form
+  #chipClear {
+    background: var(--aj-soft-control-bg);
+    border-color: var(--aj-border);
+    color: var(--aj-text-muted);
+  }
+
+  body[data-page="home"]
+  #events-filters-form
+  #chipClear:hover:not(:disabled) {
+    background: var(--aj-soft-control-hover);
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"] .events-results-count {
+    color: var(--aj-text-secondary);
+  }
+
+  html body[data-page="home"]
+  .events-results-count.is-home-preview
+  .events-results-count__text {
+    color: var(--aj-text-secondary);
+  }
+
+  html body[data-page="home"]
+  .events-results-count.is-home-preview
+  .events-results-count__cta.btn-primary {
+    background: var(--aj-soft-control-bg);
+    color: var(--aj-text-strong);
+    border: 1px solid var(--aj-border);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  html body[data-page="home"]
+  .events-results-count.is-home-preview
+  .events-results-count__cta.btn-primary:hover {
+    background: var(--aj-soft-control-hover);
+    color: var(--aj-text-strong);
+    text-decoration: none;
+  }
+
+  html body[data-page="home"]
+  .events-results-count.is-home-preview
+  .events-results-count__cta.btn-primary:focus-visible {
+    outline: 3px solid var(--aj-focus);
+    outline-offset: 3px;
+  }
+
+  body[data-page="home"]
+  .event-demo-badge.hp-banner:not(.hp-banner--london-musicals)
+  :is(.hp-banner__title, .ib-text) {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"]
+  .event-demo-badge.hp-banner:not(.hp-banner--london-musicals)
+  .hp-banner__body {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="home"]
+  .event-demo-badge.hp-banner:not(.hp-banner--london-musicals)
+  :is(.hp-banner__icon, .ib-icon) {
+    background: var(--aj-soft-control-bg);
+    border-color: var(--aj-border);
+  }
+
+  body[data-page="home"]
+  .event-demo-badge.hp-banner:not(.hp-banner--london-musicals)
+  :is(.hp-banner__cta, .ib-cta) {
+    background: var(--aj-soft-control-bg);
+    border-color: var(--aj-border);
+    color: #72c5ff;
+    box-shadow: var(--aj-card-shadow);
+  }
+
+
+  /* =======================================================
+     LOAD MORE / SKELETON
+  ======================================================= */
+
+  body:is([data-page="home"], [data-page="events"])
+  .events-load-more-wrap
+  .btn.btn-secondary {
+    background: var(--aj-soft-control-bg);
+    color: var(--aj-text-strong);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .events-load-more-wrap
+  .btn.btn-secondary:hover {
+    background: var(--aj-soft-control-hover);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .event-card.skeleton
+  .ph-img,
+  body:is([data-page="home"], [data-page="events"])
+  .event-card.skeleton
+  .ph-line {
+    background:
+      linear-gradient(
+        90deg,
+        var(--aj-skeleton-base),
+        var(--aj-skeleton-highlight),
+        var(--aj-skeleton-base)
+      );
+    background-size: 200% 100%;
+  }
+
+
+  /* =======================================================
+     EVENT MODAL
+  ======================================================= */
+
+  body:is([data-page="home"], [data-page="events"])
+  .event-modal-content {
+    background: var(--aj-surface-elevated);
+    color: var(--aj-text);
+    box-shadow: 0 18px 60px rgba(0, 0, 0, 0.48);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .event-modal-close {
+    background: var(--aj-soft-control-bg);
+    color: var(--aj-text-strong);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .event-modal-close:hover,
+  body:is([data-page="home"], [data-page="events"])
+  .event-modal-close:focus {
+    background: var(--aj-soft-control-hover);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .modal-date-location,
+  body:is([data-page="home"], [data-page="events"])
+  .modal-description {
+    color: var(--aj-text-secondary);
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .modal-category {
+    color: #72c5ff;
+  }
+
+  body:is([data-page="home"], [data-page="events"])
+  .modal-demo-note {
+    background: rgba(85, 185, 255, 0.1);
+    color: #bfe2ff;
+    border-left-color: #55b9ff;
+  }
+}

--- a/src/styles/partials/_theme-home-deferred.scss
+++ b/src/styles/partials/_theme-home-deferred.scss
@@ -1,0 +1,183 @@
+// =========================================================
+// AJSEE THEME SYSTEM V1
+// Homepage below-the-fold dark theme.
+// Loaded after the homepage component styles.
+// =========================================================
+
+@media (prefers-color-scheme: dark) {
+
+  /* ABOUT */
+
+  body[data-page="home"] .about-hero--home {
+    background: var(--aj-page-bg);
+    color: var(--aj-text);
+  }
+
+  body[data-page="home"]
+  .about-hero--home
+  .about-home-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"]
+  .about-hero--home
+  .about-home-kicker {
+    color: #55b9ff;
+  }
+
+  body[data-page="home"]
+  .about-hero--home
+  .about-home-body {
+    color: var(--aj-text-secondary);
+  }
+
+
+  /* BLOG */
+
+  body[data-page="home"] .homepage-blog {
+    background:
+      linear-gradient(
+        180deg,
+        var(--aj-surface-soft) 0%,
+        var(--aj-page-bg) 100%
+      );
+  }
+
+  body[data-page="home"] .homepage-blog h2 {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"]
+  .homepage-blog
+  :is(
+    .homepage-blog-cards > a.blog-card,
+    .homepage-blog-cards > a.homepage-blog-card,
+    .homepage-blog-cards > a.blog-card-homepage,
+    .blog-card-homepage
+  ) {
+    background: var(--aj-surface-elevated);
+    border: 1px solid var(--aj-border);
+    box-shadow: var(--aj-card-shadow);
+    color: var(--aj-text);
+  }
+
+  body[data-page="home"]
+  .homepage-blog
+  :is(
+    .homepage-blog-cards > a.blog-card,
+    .homepage-blog-cards > a.homepage-blog-card,
+    .homepage-blog-cards > a.blog-card-homepage,
+    .blog-card-homepage
+  ):hover,
+  body[data-page="home"]
+  .homepage-blog
+  :is(
+    .homepage-blog-cards > a.blog-card,
+    .homepage-blog-cards > a.homepage-blog-card,
+    .homepage-blog-cards > a.blog-card-homepage,
+    .blog-card-homepage
+  ):focus-visible {
+    box-shadow: var(--aj-card-shadow-hover);
+  }
+
+  body[data-page="home"]
+  .homepage-blog
+  :is(
+    .blog-card-content h3,
+    .blog-card-title
+  ) {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"]
+  .homepage-blog
+  :is(
+    .blog-card-content p,
+    .blog-card-lead
+  ) {
+    color: var(--aj-text-secondary);
+  }
+
+
+  /* CONTACT */
+
+  body[data-page="home"] .contact-section {
+    background:
+      radial-gradient(
+        circle at top left,
+        rgba(85, 185, 255, 0.08),
+        transparent 32%
+      ),
+      linear-gradient(
+        180deg,
+        var(--aj-page-bg) 0%,
+        var(--aj-surface-soft) 100%
+      );
+  }
+
+  body[data-page="home"] .contact-section h2 {
+    color: #72c5ff;
+  }
+
+  body[data-page="home"] .contact-form {
+    background: rgba(23, 37, 53, 0.96);
+    border-color: var(--aj-border);
+    box-shadow:
+      0 24px 64px rgba(0, 0, 0, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  body[data-page="home"]
+  .contact-form
+  .form-group
+  label {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="home"]
+  .contact-form
+  .form-group
+  :is(input, textarea) {
+    background: var(--aj-surface-soft);
+    color: var(--aj-text);
+    border-color: var(--aj-border-strong);
+  }
+
+  body[data-page="home"]
+  .contact-form
+  .form-group
+  :is(input, textarea)::placeholder {
+    color: var(--aj-text-muted);
+  }
+
+  body[data-page="home"]
+  .contact-form
+  .form-group
+  :is(input, textarea):hover {
+    background: var(--aj-surface-elevated);
+    border-color: rgba(85, 185, 255, 0.34);
+  }
+
+  body[data-page="home"]
+  .contact-form
+  .form-group
+  :is(input, textarea):focus,
+  body[data-page="home"]
+  .contact-form
+  .form-group
+  :is(input, textarea):focus-visible {
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-focus);
+    box-shadow:
+      0 0 0 4px rgba(85, 185, 255, 0.16),
+      0 8px 24px rgba(0, 0, 0, 0.2);
+  }
+
+  body[data-page="home"] .contact-form a {
+    color: #72c5ff;
+  }
+
+  body[data-page="home"] .contact-form p {
+    color: var(--aj-text-secondary);
+  }
+}

--- a/src/styles/partials/_theme-partners.scss
+++ b/src/styles/partials/_theme-partners.scss
@@ -1,0 +1,373 @@
+/* =========================================================
+   AJSEE Partners theme adapter
+   - Dark Mode only
+   - Scoped exclusively to /partners
+   - Loaded after contact.scss intentionally
+========================================================= */
+
+@media (prefers-color-scheme: dark) {
+
+  body[data-page="partners"] {
+    background: var(--aj-page-bg);
+    color: var(--aj-text);
+  }
+
+  body[data-page="partners"] main {
+    background: var(--aj-page-bg);
+  }
+
+
+  /* -------------------------------------------------------
+     Hero
+     Dark Mode keeps the premium blue identity, but uses
+     substantially darker surfaces for visual continuity.
+  ------------------------------------------------------- */
+
+  body[data-page="partners"] .partners-hero {
+    background:
+      radial-gradient(
+        720px 380px at 70% 14%,
+        rgba(73, 191, 255, 0.10) 0%,
+        rgba(73, 191, 255, 0) 64%
+      ),
+      radial-gradient(
+        860px 520px at 92% 82%,
+        rgba(20, 194, 197, 0.08) 0%,
+        rgba(20, 194, 197, 0) 72%
+      ),
+      radial-gradient(
+        820px 520px at 8% 16%,
+        rgba(0, 0, 0, 0.24) 0%,
+        rgba(0, 0, 0, 0) 66%
+      ),
+      linear-gradient(
+        110deg,
+        #071a2b 0%,
+        #0a2b43 44%,
+        #0d3a52 72%,
+        #102f3c 100%
+      );
+  }
+
+  body[data-page="partners"]
+  .partners-hero
+  .partners-hero-content {
+    color: #f3f7fb;
+  }
+
+  body[data-page="partners"]
+  .partners-hero
+  .partner-benefits
+  li {
+    background:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.11) 0%,
+        rgba(255, 255, 255, 0.055) 100%
+      );
+    border-color: rgba(255, 255, 255, 0.14);
+    box-shadow:
+      0 14px 28px rgba(0, 0, 0, 0.18),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+
+  /* -------------------------------------------------------
+     Main content sections
+  ------------------------------------------------------- */
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-section,
+    .partners-collaboration-section,
+    .partners-process-section,
+    .partners-value-section
+  ) {
+    background: var(--aj-page-bg);
+  }
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-shell,
+    .partners-collaboration-shell,
+    .partners-process-shell,
+    .partners-value-shell
+  ) {
+    background: var(--aj-surface);
+    border-color: var(--aj-border);
+    box-shadow:
+      0 24px 54px rgba(0, 0, 0, 0.24),
+      0 8px 20px rgba(0, 0, 0, 0.16);
+  }
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-title,
+    .partners-collaboration-title,
+    .partners-process-title,
+    .partners-value-title
+  ) {
+    color: var(--aj-accent-text);
+  }
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-head,
+    .partners-collaboration-head,
+    .partners-process-head,
+    .partners-value-head
+  )
+  > p {
+    color: var(--aj-text-secondary);
+  }
+
+
+  /* -------------------------------------------------------
+     Content cards
+  ------------------------------------------------------- */
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-card,
+    .partners-collaboration-card,
+    .partners-process-card,
+    .partners-value-card
+  ) {
+    background: var(--aj-surface-soft);
+    border-color: var(--aj-border);
+    box-shadow:
+      0 10px 24px rgba(0, 0, 0, 0.18),
+      0 3px 8px rgba(0, 0, 0, 0.12);
+  }
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-card,
+    .partners-collaboration-card,
+    .partners-process-card,
+    .partners-value-card
+  ):is(:hover, :focus-within) {
+    background: var(--aj-surface-elevated);
+    border-color: rgba(114, 197, 255, 0.28);
+    box-shadow:
+      0 16px 30px rgba(0, 0, 0, 0.26),
+      0 6px 14px rgba(0, 0, 0, 0.18);
+  }
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-card,
+    .partners-collaboration-card,
+    .partners-process-card,
+    .partners-value-card
+  )
+  h3 {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="partners"]
+  :is(
+    .partners-focus-card,
+    .partners-collaboration-card,
+    .partners-process-card,
+    .partners-value-card
+  )
+  p {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="partners"] .partners-process-note {
+    background: var(--aj-soft-control-bg);
+    border-color: var(--aj-border);
+    color: var(--aj-text-secondary);
+  }
+
+
+  /* -------------------------------------------------------
+     Contact section
+     Blue left-hand partner panel remains branded.
+  ------------------------------------------------------- */
+
+  body[data-page="partners"] .partner-contact-section {
+    background: var(--aj-page-bg);
+  }
+
+  body[data-page="partners"] .partner-contact-shell {
+    background: var(--aj-surface);
+    border-color: var(--aj-border);
+    box-shadow:
+      0 24px 60px rgba(0, 0, 0, 0.28),
+      0 8px 22px rgba(0, 0, 0, 0.18);
+  }
+
+  body[data-page="partners"] .partner-contact-copy {
+    background:
+      radial-gradient(
+        circle at 90% 8%,
+        rgba(85, 185, 255, 0.16) 0%,
+        rgba(85, 185, 255, 0) 44%
+      ),
+      linear-gradient(
+        145deg,
+        #0a3d62 0%,
+        #0b5278 54%,
+        #116785 100%
+      );
+    color: #f3f7fb;
+    box-shadow:
+      0 18px 38px rgba(0, 0, 0, 0.26),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  body[data-page="partners"] .partner-contact-form-card {
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-border);
+    box-shadow:
+      0 14px 34px rgba(0, 0, 0, 0.22),
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  body[data-page="partners"] .partner-contact-form-card h3 {
+    color: var(--aj-accent-text);
+  }
+
+
+  /* -------------------------------------------------------
+     Partner form
+     These selectors intentionally beat contact.scss,
+     which is loaded before this adapter.
+  ------------------------------------------------------- */
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form {
+    background: var(--aj-form-panel-bg);
+    border-color: var(--aj-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group
+  label {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group
+  :is(input, textarea) {
+    background: var(--aj-form-control-bg);
+    color: var(--aj-form-control-text);
+    border-color: var(--aj-form-border);
+  }
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group
+  :is(input, textarea)::placeholder {
+    color: var(--aj-form-placeholder);
+  }
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group
+  :is(input, textarea):hover {
+    background: var(--aj-form-control-hover);
+    border-color: var(--aj-form-border-hover);
+  }
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group
+  :is(input, textarea):is(:focus, :focus-visible) {
+    background: var(--aj-form-control-focus);
+    border-color: var(--aj-focus);
+    box-shadow:
+      0 0 0 4px rgba(85, 185, 255, 0.16),
+      0 8px 18px rgba(0, 0, 0, 0.18);
+  }
+
+
+  /* Invalid controls - contact.scss has high-specificity rules. */
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group.is-invalid
+  :is(input, textarea),
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group
+  input[aria-invalid="true"],
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group
+  textarea[aria-invalid="true"] {
+    background: var(--aj-form-error-bg);
+    border-color: var(--aj-form-error-border);
+    color: var(--aj-form-control-text);
+    box-shadow: 0 0 0 4px rgba(255, 107, 120, 0.12);
+  }
+
+
+  /* Valid controls - kept for compatibility with shared contact UX. */
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-group.is-valid
+  :is(input, textarea) {
+    background: var(--aj-form-success-bg);
+    border-color: var(--aj-form-success-border);
+    color: var(--aj-form-control-text);
+  }
+
+
+  /* Inline field errors */
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-form
+  .form-error,
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .form-error {
+    color: var(--aj-form-error-text);
+    background: var(--aj-form-error-bg);
+    border-color: var(--aj-form-error-border);
+  }
+
+
+  /* Submit-level error */
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-error {
+    color: var(--aj-form-error-text);
+    background: var(--aj-form-error-bg);
+    border-color: var(--aj-form-error-border);
+  }
+
+
+  /* Successful submit */
+
+  body[data-page="partners"]
+  .partner-contact-section
+  .contact-success {
+    color: var(--aj-form-success-text);
+    background: var(--aj-form-success-bg);
+    border-color: var(--aj-form-success-border);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
+  }
+}

--- a/src/styles/partials/about-page.scss
+++ b/src/styles/partials/about-page.scss
@@ -109,7 +109,7 @@
 
     .about-hero-text {
       font-size: 1.18rem;
-      color: #224;
+      color: var(--aj-about-text-neutral, #224);
       line-height: 1.65;
       margin-bottom: 0;
 
@@ -678,11 +678,11 @@
 
     .about-future-text{
       font-size: 1.18rem;
-      color: #184469;
+      color: var(--aj-about-text, #184469);
       line-height: 1.7;
 
       p{ margin-bottom: 0.1rem; }
-      strong{ color:#000; font-weight:700; }
+      strong{ color:var(--aj-about-strong, #000); font-weight:700; }
     }
   }
 
@@ -798,4 +798,93 @@
     .about-cta-text { font-size: 1.01rem; margin-bottom: 1.2rem; }
     .about-cta-actions .btn-primary { font-size: 0.97rem; padding: 0.7em 1.3em; }
   }
+}
+
+/* =========================================================
+   AJSEE ABOUT THEME MAPPING V1
+   Light fallbacks preserve the existing About appearance.
+========================================================= */
+
+body[data-page="about"] {
+  background: var(--aj-page-bg, #f9f9f9);
+  color: var(--aj-text, #22223b);
+}
+
+body[data-page="about"] .about-hero,
+body[data-page="about"] .about-cta {
+  background: var(
+    --aj-about-hero-bg,
+    linear-gradient(120deg, #f2f8fd 0%, #d3e6f8 100%)
+  );
+}
+
+body[data-page="about"] .about-story {
+  background: var(--aj-about-story-bg, #ffffff);
+}
+
+body[data-page="about"] .about-future {
+  background: var(
+    --aj-about-future-bg,
+    linear-gradient(120deg, #f8fcff 0%, #e9f3ff 100%)
+  );
+}
+
+body[data-page="about"] .about-team {
+  background: var(
+    --aj-about-team-bg,
+    linear-gradient(120deg, #f8fcff 0%, #e1f5fb 100%)
+  );
+}
+
+body[data-page="about"] .about-hero-textblock h1,
+body[data-page="about"] .about-story h2,
+body[data-page="about"] .about-future h2,
+body[data-page="about"] .about-team h2,
+body[data-page="about"] .about-cta h2 {
+  color: var(--aj-about-heading, #0077cc);
+}
+
+body[data-page="about"] .about-hero-text,
+body[data-page="about"] .about-cta-text {
+  color: var(--aj-about-text-neutral, #222244);
+}
+
+body[data-page="about"] .about-story-text,
+body[data-page="about"] .about-future-text,
+body[data-page="about"] .team-name {
+  color: var(--aj-about-text, #184469);
+}
+
+body[data-page="about"] .about-story-text strong,
+body[data-page="about"] .about-future-text strong {
+  color: var(--aj-about-strong, #000000);
+}
+
+body[data-page="about"] .about-hero-text strong {
+  color: var(--aj-about-accent, #0f9aa0);
+}
+
+body[data-page="about"] .team-member {
+  background: var(--aj-about-card-bg, #ffffff);
+}
+
+body[data-page="about"] .team-name {
+  color: var(--aj-about-card-text, #184469);
+}
+
+body[data-page="about"] .team-role {
+  color: var(--aj-about-accent, #14c2c5);
+}
+
+body[data-page="about"] .team-claim {
+  color: var(--aj-about-card-secondary, #334b69);
+}
+
+body[data-page="about"] .team-photo {
+  border-color: var(--aj-about-photo-border, #ffffff);
+  background: var(--aj-about-photo-bg, #e1f5fb);
+}
+
+body[data-page="about"] .team-linkedin img {
+  background: var(--aj-about-icon-bg, #eaf5fc);
 }

--- a/src/styles/partials/blog-page.scss
+++ b/src/styles/partials/blog-page.scss
@@ -780,3 +780,269 @@
 body.article-image-lightbox-open {
   overflow: hidden;
 }
+/* AJSEE CONTENT FAMILY DARK V1 */
+@media (prefers-color-scheme: dark) {
+
+  body[data-page="blog"],
+  body[data-page="blog-detail"],
+  body[data-page="review-detail"] {
+    background: var(--aj-page-bg);
+    color: var(--aj-text);
+  }
+
+  body[data-page="blog"] main,
+  body[data-page="blog-detail"] main,
+  body[data-page="review-detail"] main {
+    background: var(--aj-page-bg);
+  }
+
+
+  /* -------------------------------------------------------
+     Blog listing
+  ------------------------------------------------------- */
+
+  body[data-page="blog"] .blog-hero {
+    background:
+      linear-gradient(
+        120deg,
+        #0b1724 0%,
+        #123044 100%
+      );
+  }
+
+  body[data-page="blog"] .blog-hero h1 {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="blog"] .blog-hero .blog-lead {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="blog"] .blog-filters,
+  body[data-page="blog"] .blog-list {
+    background: var(--aj-page-bg);
+  }
+
+  body[data-page="blog"]
+  .blog-filters
+  .filter-categories
+  button {
+    background: var(--aj-surface);
+    color: #59dfe2;
+    border-color: #14c2c5;
+  }
+
+  body[data-page="blog"]
+  .blog-filters
+  .filter-categories
+  button:hover,
+  body[data-page="blog"]
+  .blog-filters
+  .filter-categories
+  button.active {
+    background: #0f9aa0;
+    color: #ffffff;
+    border-color: #0f9aa0;
+  }
+
+  body[data-page="blog"] .blog-list .blog-card {
+    background: var(--aj-surface);
+    border: 1px solid var(--aj-border);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="blog"]
+  .blog-list
+  .blog-card:hover,
+  body[data-page="blog"]
+  .blog-list
+  .blog-card:focus-within {
+    box-shadow: var(--aj-card-shadow-hover);
+  }
+
+  body[data-page="blog"]
+  .blog-list
+  .blog-card
+  .blog-card-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="blog"]
+  .blog-list
+  .blog-card
+  .blog-card-lead {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="blog"]
+  .blog-list
+  .blog-card.is-microguide
+  .card-media {
+    background: var(--aj-media-placeholder);
+  }
+
+  body[data-page="blog"] .blog-empty {
+    color: #ffb4bd;
+  }
+
+
+  /* -------------------------------------------------------
+     Blog article + generated review detail
+  ------------------------------------------------------- */
+
+  body[data-page="blog-detail"] .blog-detail,
+  body[data-page="review-detail"] .blog-detail {
+    background: var(--aj-page-bg);
+  }
+
+  body[data-page="blog-detail"]
+  .blog-detail
+  .container,
+  body[data-page="review-detail"]
+  .blog-detail
+  .container {
+    background: var(--aj-surface);
+    border: 1px solid var(--aj-border);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="blog-detail"]
+  .blog-detail
+  .blog-title,
+  body[data-page="review-detail"]
+  .blog-detail
+  .blog-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="blog-detail"]
+  .blog-detail
+  .blog-lead,
+  body[data-page="review-detail"]
+  .blog-detail
+  .blog-lead {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="blog-detail"]
+  .blog-detail
+  .blog-content,
+  body[data-page="review-detail"]
+  .blog-detail
+  .blog-content {
+    color: var(--aj-text);
+  }
+
+  body[data-page="blog-detail"]
+  .blog-detail
+  .back-link,
+  body[data-page="review-detail"]
+  .blog-detail
+  .back-link,
+  body[data-page="blog-detail"]
+  .blog-detail
+  .blog-meta,
+  body[data-page="review-detail"]
+  .blog-detail
+  .blog-meta {
+    color: #59dfe2;
+  }
+
+
+  /* Review details */
+
+  body[data-page="review-detail"] .review-cover-credit,
+  body[data-page="review-detail"] .review-gallery-item figcaption {
+    color: var(--aj-text-muted);
+  }
+
+  body[data-page="review-detail"] .review-gallery-title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="review-detail"] .review-gallery-item {
+    border-color: var(--aj-border);
+  }
+
+
+  /* -------------------------------------------------------
+     Review engagement
+  ------------------------------------------------------- */
+
+  body[data-page="review-detail"] .review-engagement {
+    border-color: var(--aj-border);
+    background:
+      linear-gradient(
+        135deg,
+        rgba(20, 194, 197, 0.08),
+        rgba(85, 185, 255, 0.055)
+      ),
+      var(--aj-surface-soft);
+    box-shadow: var(--aj-card-shadow);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__title {
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__description {
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__button {
+    border-color: var(--aj-border-strong);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__button--share {
+    background: #1a3044;
+    color: var(--aj-text-strong);
+    border-color: var(--aj-border-strong);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__button--copy,
+  body[data-page="review-detail"]
+  .review-engagement__button--like {
+    background: var(--aj-surface-elevated);
+    color: var(--aj-text-strong);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__read-metric {
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-border);
+    color: var(--aj-text-secondary);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__like-count {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__read-count.is-loading::after,
+  body[data-page="review-detail"]
+  .review-engagement__like-count.is-loading::after {
+    background:
+      linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.05),
+        rgba(255, 255, 255, 0.13),
+        rgba(255, 255, 255, 0.05)
+      );
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__status {
+    color: #9ee7c6;
+  }
+
+  body[data-page="review-detail"]
+  .review-engagement__status.is-error {
+    color: #ffb4bd;
+  }
+}

--- a/src/styles/partials/blog.scss
+++ b/src/styles/partials/blog.scss
@@ -13,7 +13,7 @@
   h2 {
     text-align: center;
     font-size: 2.1rem;
-    color: #184469;
+    color: var(--aj-home-blog-title, #184469);
     margin-bottom: 2.2rem;
     font-weight: 800;
     letter-spacing: -0.7px;
@@ -91,14 +91,14 @@
       h3 {
         font-size: 1.17rem;
         font-weight: 800;
-        color: #184469;
+        color: var(--aj-home-blog-title, #184469);
         margin-bottom: 0.5rem;
         letter-spacing: -0.3px;
         line-height: 1.24;
       }
 
       p {
-        color: #334b69;
+        color: var(--aj-home-blog-text, #334b69);
         font-size: 1.04rem;
         margin-bottom: 0.8rem;
         flex: 1 1 0;
@@ -137,7 +137,7 @@
     .blog-card-title {
       font-size: 1.17rem;
       font-weight: 800;
-      color: #184469;
+      color: var(--aj-home-blog-title, #184469);
       margin-bottom: 0.5rem;
       letter-spacing: -0.3px;
       line-height: 1.24;

--- a/src/styles/partials/events.scss
+++ b/src/styles/partials/events.scss
@@ -437,12 +437,15 @@
    ------------------------ */
 
 .event-demo-badge:not(.hp-banner){
-  --ib-bg: radial-gradient(120% 120% at 0% 0%, #f5fbff 0%, #eef7ff 40%, #ffffff 100%);
-  --ib-border: rgba(7, 38, 77, .09);
-  --ib-shadow: 0 10px 30px rgba(8, 60, 130, .08);
-  --ib-text: #0d2235;
-  --ib-accent: #0b74e5;
-  --ib-accent-hover: #085ab5;
+  --ib-bg: var(
+    --aj-events-info-banner-bg,
+    radial-gradient(120% 120% at 0% 0%, #f5fbff 0%, #eef7ff 40%, #ffffff 100%)
+  );
+  --ib-border: var(--aj-events-info-banner-border, rgba(7, 38, 77, .09));
+  --ib-shadow: var(--aj-events-info-banner-shadow, 0 10px 30px rgba(8, 60, 130, .08));
+  --ib-text: var(--aj-events-info-banner-text, #0d2235);
+  --ib-accent: var(--aj-events-info-banner-accent, #0b74e5);
+  --ib-accent-hover: var(--aj-events-info-banner-accent-hover, #085ab5);
 
   display: grid;
   grid-template-columns: minmax(36px,auto) 1fr auto;

--- a/src/styles/partials/faq.scss
+++ b/src/styles/partials/faq.scss
@@ -117,3 +117,36 @@
   from { opacity: 0; transform: translateY(-10px);}
   to { opacity: 1; transform: translateY(0);}
 }
+/* AJSEE FAQ DARK V1 */
+@media (prefers-color-scheme: dark) {
+  .faq-section {
+    background: var(--aj-page-bg, #09131f);
+
+    h1 {
+      color: var(--aj-text-strong, #f3f7fb);
+    }
+
+    .faq-item {
+      background: var(--aj-surface, #101c2a);
+      border-color: var(--aj-border, rgba(255, 255, 255, 0.12));
+      box-shadow: var(--aj-card-shadow, 0 8px 24px rgba(0, 0, 0, 0.24));
+
+      &:hover {
+        border-color: $color-primary;
+        box-shadow: var(--aj-card-shadow-hover, 0 14px 36px rgba(0, 0, 0, 0.34));
+      }
+
+      .faq-question {
+        color: var(--aj-text-strong, #f3f7fb);
+
+        &:focus-visible {
+          outline-color: var(--aj-focus, #55b9ff);
+        }
+      }
+
+      .faq-answer {
+        color: var(--aj-text-secondary, #b3c2d2);
+      }
+    }
+  }
+}

--- a/src/styles/partials/filters-premium.scss
+++ b/src/styles/partials/filters-premium.scss
@@ -18,31 +18,31 @@
 
 /* ─── Design tokens ─── */
 :root {
-  --flt-bg: rgba(255, 255, 255, 0.62);
+  --flt-bg: var(--aj-filter-legacy-bg);
   --flt-blur: 14px;
-  --flt-brd: rgba(255, 255, 255, 0.5);
-  --flt-brd-2: rgba(13, 30, 60, 0.08);
-  --flt-shadow: 0 24px 48px rgba(12, 36, 80, 0.12), 0 2px 6px rgba(12, 36, 80, 0.06);
+  --flt-brd: var(--aj-filter-legacy-border);
+  --flt-brd-2: var(--aj-filter-legacy-border-2);
+  --flt-shadow: var(--aj-filter-legacy-shadow);
   --flt-radius: 20px;
 
-  --ink-1: #071a2b;
-  --ink-2: #173a62;
-  --ink-3: #6a86a8;
+  --ink-1: var(--aj-filter-ink-1);
+  --ink-2: var(--aj-filter-ink-2);
+  --ink-3: var(--aj-filter-ink-3);
 
-  --chip-bg: #f4f8ff;
-  --chip-text: #0b2640;
-  --chip-shadow: 0 8px 18px rgba(12, 36, 80, 0.1);
+  --chip-bg: var(--aj-filter-chip-bg);
+  --chip-text: var(--aj-filter-chip-text);
+  --chip-shadow: var(--aj-filter-chip-shadow);
 
   --cta-1: #0e88f0;
   --cta-2: #0b5ed7;
 
-  --seg-bg: #eef3fb;
+  --seg-bg: var(--aj-filter-segment-bg);
   --seg-shadow: 0 12px 22px rgba(12, 36, 80, 0.12);
 
   --near-1: #006fbe;
   --near-2: #00c0d9;
 
-  --focus: #69b3ff;
+  --focus: var(--aj-focus);
 
   --font-sans: "Plus Jakarta Sans", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
 
@@ -58,32 +58,14 @@
   --ajsee-popover-top: 16px;
   --ajsee-popover-height: 560px;
 
-  --glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.72));
-  --glass-brd: linear-gradient(135deg, #e7f0ff, #f6f9ff);
-  --glass-shadow: 0 10px 24px rgba(12, 36, 80, 0.15), 0 1px 0 rgba(255, 255, 255, 0.7) inset;
+  --glass-bg: var(--aj-filter-glass-bg);
+  --glass-brd: var(--aj-filter-glass-border);
+  --glass-shadow: var(--aj-filter-glass-shadow);
 
   --active-pill-bg: linear-gradient(120deg, #0e88f0, #14c2c5);
   --active-pill-shadow: 0 18px 34px rgba(14, 136, 240, 0.3);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --flt-bg: rgba(17, 21, 32, 0.58);
-    --flt-brd: rgba(255, 255, 255, 0.08);
-    --flt-brd-2: rgba(255, 255, 255, 0.1);
-    --chip-bg: rgba(255, 255, 255, 0.08);
-    --chip-text: #e8f0ff;
-    --seg-bg: rgba(255, 255, 255, 0.08);
-
-    --ink-1: #eaf0ff;
-    --ink-2: #d6e6ff;
-    --ink-3: #a6b7d7;
-
-    --glass-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.06));
-    --glass-brd: linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.1));
-    --glass-shadow: 0 10px 24px rgba(0, 0, 0, 0.4), 0 1px 0 rgba(255, 255, 255, 0.06) inset;
-  }
-}
 
 /* ─── Panel filtrů ─── */
 :where(.events-filters.filter-dock),
@@ -351,18 +333,16 @@
     input[type="date"],
     input[type="search"],
     input[type="text"] {
-      background:
-        linear-gradient(rgba(15, 23, 42, 0.92), rgba(15, 23, 42, 0.96)) padding-box,
-        linear-gradient(135deg, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.1)) border-box;
-      color: #f2f6ff;
-      box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+      background: var(--aj-filter-control-surface);
+      color: var(--aj-filter-control-text);
+      box-shadow: var(--aj-filter-control-shadow);
     }
 
     input.styled-input::placeholder,
     input[type="date"]::placeholder,
     input[type="search"]::placeholder,
     input[type="text"]::placeholder {
-      color: #cfe0ff;
+      color: var(--aj-filter-control-muted);
       opacity: 0.92;
     }
   }
@@ -666,16 +646,8 @@
 
 :where(.events-filters.filter-dock, form.filter-dock)
   :is(select.styled-select, #filter-category, #events-category-filter) option {
-  background: #ffffff;
-  color: var(--ink-1);
-}
-
-@media (prefers-color-scheme: dark) {
-  :where(.events-filters.filter-dock, form.filter-dock)
-    :is(select.styled-select, #filter-category, #events-category-filter) option {
-    background: #0b1220;
-    color: #e6f0ff;
-  }
+  background: var(--aj-filter-option-bg);
+  color: var(--aj-filter-option-text);
 }
 
 :where(.events-filters.filter-dock, form.filter-dock) input[type="date"]::-webkit-calendar-picker-indicator {
@@ -814,8 +786,8 @@
     .tomselect .ts-dropdown,
     .nice-select .list
   ) {
-    border-color: rgba(255, 255, 255, 0.1);
-    outline-color: rgba(255, 255, 255, 0.08);
+    border-color: var(--aj-filter-vendor-border);
+    outline-color: var(--aj-filter-vendor-outline);
   }
 }
 
@@ -954,17 +926,15 @@ html body .suggestions.suggestions [aria-selected="true"] {
   html body .typeahead-list.typeahead-list,
   html body .autocomplete-list.autocomplete-list,
   html body .suggestions.suggestions {
-    border-color: rgba(255, 255, 255, 0.1);
-    background:
-      radial-gradient(60% 80% at 30% 0%, rgba(255, 255, 255, 0.08), transparent 60%),
-      rgba(15, 23, 42, 0.72);
-    box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    border-color: var(--aj-filter-typeahead-border);
+    background: var(--aj-filter-typeahead-bg);
+    box-shadow: var(--aj-filter-typeahead-shadow);
   }
 
   html body .tt-menu.tt-menu .tt-suggestion:hover,
   html body .tt-menu.tt-menu .tt-cursor,
   html body .tt-menu.tt-menu [aria-selected="true"] {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--aj-filter-typeahead-hover);
   }
 }
 

--- a/src/styles/partials/footer.scss
+++ b/src/styles/partials/footer.scss
@@ -7,9 +7,9 @@
   text-align: center;
   padding: 2rem 1rem;
   font-size: 0.93rem;
-  color: #666;
-  background: #fafafa;
-  border-top: 1px solid $brand-grey;
+  color: var(--aj-footer-text, #666);
+  background: var(--aj-footer-bg, #fafafa);
+  border-top: 1px solid var(--aj-footer-border, #{$brand-grey});
   margin-top: 0;
 }
 
@@ -62,7 +62,7 @@
 
 .footer-copy {
   font-weight: 500;
-  color: #4a4a4a;
+  color: var(--aj-footer-copy, #4a4a4a);
 }
 
 .footer-legal {
@@ -75,7 +75,7 @@
 }
 
 .footer-legal-link {
-  color: $brand-blue;
+  color: var(--aj-footer-link, #{$brand-blue});
   text-decoration: none;
   transition: color 0.2s ease, opacity 0.2s ease;
 
@@ -92,20 +92,20 @@
 }
 
 .footer-legal-separator {
-  color: #999;
+  color: var(--aj-footer-separator, #999);
   user-select: none;
 }
 
 .footer-company {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--aj-footer-text, #666);
 }
 
 .footer-contact {
   font-size: 0.9rem;
 
   a {
-    color: $brand-blue;
+    color: var(--aj-footer-link, #{$brand-blue});
     text-decoration: none;
 
     &:hover,
@@ -184,7 +184,7 @@
 
 .footer-legal-link,
 .footer-legal-button {
-  color: $brand-blue;
+  color: var(--aj-footer-link, #{$brand-blue});
   font: inherit;
   line-height: 1.6;
   text-decoration: none;
@@ -212,5 +212,5 @@
 }
 
 .footer-legal-separator {
-  color: #9aa6b2;
+  color: var(--aj-footer-separator, #9aa6b2);
 }

--- a/src/styles/utils/_theme.scss
+++ b/src/styles/utils/_theme.scss
@@ -1,0 +1,580 @@
+/* =========================================================
+   AJSEE THEME SYSTEM V1
+   Semantic color tokens for theme-aware components.
+========================================================= */
+
+:root {
+  --aj-theme: light;
+
+  /* Core */
+  --aj-page-bg: #f9f9f9;
+  --aj-surface: #ffffff;
+  --aj-surface-soft: #f5f9fc;
+  --aj-surface-elevated: #ffffff;
+
+  --aj-text: #22223b;
+  --aj-text-strong: #10283f;
+  --aj-text-secondary: #647b91;
+  --aj-text-muted: #7e93ac;
+
+  --aj-border: rgba(224, 235, 245, 0.92);
+  --aj-border-strong: #ccddee;
+  --aj-focus: #0077cc;
+
+  /* Shared page surfaces */
+  --aj-surface-hover: #eef7ff;
+  --aj-media-placeholder: #eaf6fb;
+
+  --aj-card-shadow: 0 2px 12px rgba(0, 119, 204, 0.09);
+  --aj-card-shadow-hover: 0 8px 30px rgba(0, 119, 204, 0.14);
+
+  --aj-soft-control-bg: #eef4fb;
+  --aj-soft-control-hover: #e2edf9;
+
+  --aj-skeleton-base: #eef3f8;
+  --aj-skeleton-highlight: #f6f9fc;
+
+  --aj-events-hero-bg:
+    linear-gradient(120deg, #e9f3ff 0%, #eaf8fa 100%);
+
+  --aj-home-promo-bg:
+    radial-gradient(
+      circle at 12% 24%,
+      rgba(20, 194, 197, 0.18),
+      transparent 16rem
+    ),
+    linear-gradient(
+      135deg,
+      rgba(234, 252, 255, 0.96),
+      rgba(247, 252, 255, 0.92)
+    );
+
+  --aj-home-promo-icon-bg:
+    linear-gradient(135deg, #eafcff, #d6f7fb);
+
+  --aj-home-promo-title: #06192b;
+  --aj-home-promo-body: rgba(16, 32, 51, 0.72);
+
+  --aj-home-muted-banner-bg: rgba(255, 255, 255, 0.68);
+  --aj-home-muted-banner-border: rgba(14, 107, 168, 0.16);
+
+  /* Shared content + forms */
+  --aj-accent-text: #0077cc;
+
+  --aj-form-panel-bg: #ffffff;
+  --aj-form-control-bg: #f8fbff;
+  --aj-form-control-hover: #fbfdff;
+  --aj-form-control-focus: #ffffff;
+  --aj-form-control-text: #22223b;
+  --aj-form-placeholder: #7f8b99;
+  --aj-form-border: rgba(0, 119, 204, 0.16);
+  --aj-form-border-hover: rgba(0, 119, 204, 0.28);
+
+  --aj-form-error-bg: #fff7f7;
+  --aj-form-error-text: #9b1c1c;
+  --aj-form-error-border: rgba(228, 90, 90, 0.24);
+
+  --aj-form-success-bg: #edfdf7;
+  --aj-form-success-text: #0f6149;
+  --aj-form-success-border: #bdebd9;
+
+  /* About page */
+  --aj-about-hero-bg:
+    linear-gradient(120deg, #f2f8fd 0%, #d3e6f8 100%);
+  --aj-about-story-bg: #ffffff;
+  --aj-about-future-bg:
+    linear-gradient(120deg, #f8fcff 0%, #e9f3ff 100%);
+  --aj-about-team-bg:
+    linear-gradient(120deg, #f8fcff 0%, #e1f5fb 100%);
+
+  --aj-about-heading: #0077cc;
+  --aj-about-text: #184469;
+  --aj-about-text-neutral: #222244;
+  --aj-about-strong: #000000;
+  --aj-about-accent: #0f9aa0;
+
+  --aj-about-card-bg: #ffffff;
+  --aj-about-card-text: #184469;
+  --aj-about-card-secondary: #334b69;
+
+  --aj-about-photo-border: #ffffff;
+  --aj-about-photo-bg: #e1f5fb;
+  --aj-about-icon-bg: #eaf5fc;
+
+  --aj-about-route-bg-start: #ffffff;
+  --aj-about-route-bg-1: #eaf6ff;
+  --aj-about-route-bg-2: #dff1ff;
+
+  /* Event provider badges */
+  --aj-provider-badge-bg: rgba(10, 61, 98, 0.045);
+  --aj-provider-badge-border: rgba(10, 61, 98, 0.12);
+  --aj-provider-badge-text: #0a3d62;
+
+  --aj-provider-smsticket-bg: rgba(92, 70, 255, 0.08);
+  --aj-provider-smsticket-border: rgba(92, 70, 255, 0.16);
+  --aj-provider-smsticket-text: #342f75;
+
+  --aj-provider-ticketmaster-bg: rgba(0, 116, 224, 0.08);
+  --aj-provider-ticketmaster-border: rgba(0, 116, 224, 0.16);
+  --aj-provider-ticketmaster-text: #064c9b;
+
+  /* Event detail modal */
+  --aj-modal-bg: rgba(255, 255, 255, 0.98);
+  --aj-modal-border: rgba(217, 225, 239, 0.95);
+  --aj-modal-shadow: 0 28px 80px rgba(9, 30, 66, 0.28);
+
+  --aj-modal-title: #102033;
+  --aj-modal-meta: #526071;
+  --aj-modal-description: #344054;
+  --aj-modal-secondary: #667085;
+  --aj-modal-category: #667085;
+
+  --aj-modal-close-bg: rgba(255, 255, 255, 0.92);
+  --aj-modal-close-text: #14213d;
+  --aj-modal-image-bg: #eef5ff;
+
+  --aj-modal-control-bg: #ffffff;
+  --aj-modal-control-hover: #f5f9fd;
+  --aj-modal-control-border: rgba(10, 61, 98, 0.18);
+  --aj-modal-control-border-hover: rgba(10, 61, 98, 0.32);
+  --aj-modal-control-text: #0a3d62;
+
+  /* Events announcement / TrustedStays */
+  --aj-events-info-banner-bg:
+    radial-gradient(120% 120% at 0% 0%, #f5fbff 0%, #eef7ff 40%, #ffffff 100%);
+  --aj-events-info-banner-border: rgba(7, 38, 77, 0.09);
+  --aj-events-info-banner-shadow: 0 10px 30px rgba(8, 60, 130, 0.08);
+  --aj-events-info-banner-text: #0d2235;
+  --aj-events-info-banner-accent: #0b74e5;
+  --aj-events-info-banner-accent-hover: #085ab5;
+
+  /* Events pagination */
+  --aj-pager-status: #667085;
+  --aj-pager-button-bg: #ffffff;
+  --aj-pager-button-text: #0a3d62;
+  --aj-pager-button-border: rgba(10, 61, 98, 0.16);
+  --aj-pager-button-shadow: 0 8px 20px rgba(9, 30, 66, 0.06);
+  --aj-pager-button-shadow-hover: 0 12px 28px rgba(9, 30, 66, 0.10);
+  --aj-pager-primary-bg: #0a3d62;
+  --aj-pager-primary-text: #ffffff;
+  --aj-pager-primary-border: #0a3d62;
+
+  /*
+     Legacy filter compatibility.
+     These values intentionally preserve the existing LIGHT appearance
+     while the old filter layer is migrated to semantic tokens.
+  */
+  --aj-filter-legacy-bg: rgba(255, 255, 255, 0.62);
+  --aj-filter-legacy-border: rgba(255, 255, 255, 0.5);
+  --aj-filter-legacy-border-2: rgba(13, 30, 60, 0.08);
+  --aj-filter-legacy-shadow:
+    0 24px 48px rgba(12, 36, 80, 0.12),
+    0 2px 6px rgba(12, 36, 80, 0.06);
+
+  --aj-filter-ink-1: #071a2b;
+  --aj-filter-ink-2: #173a62;
+  --aj-filter-ink-3: #6a86a8;
+
+  --aj-filter-option-bg: #ffffff;
+  --aj-filter-option-text: #071a2b;
+
+  --aj-filter-vendor-border: rgba(13, 30, 60, 0.1);
+  --aj-filter-vendor-outline: rgba(13, 30, 60, 0.08);
+
+  --aj-filter-typeahead-border: rgba(13, 30, 60, 0.1);
+  --aj-filter-typeahead-bg:
+    radial-gradient(
+      60% 80% at 30% 0%,
+      rgba(255, 255, 255, 0.55),
+      transparent 60%
+    ),
+    rgba(255, 255, 255, 0.92);
+  --aj-filter-typeahead-shadow:
+    0 24px 48px rgba(12, 36, 80, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  --aj-filter-typeahead-hover:
+    color-mix(in oklab, #0b5ed7 10%, #fff 90%);
+
+  /* Event filter shell */
+  --aj-filter-panel-bg:
+    linear-gradient(
+      180deg,
+      rgba(248, 252, 255, 0.98) 0%,
+      rgba(242, 248, 253, 0.96) 100%
+    );
+  --aj-filter-panel-border: rgba(224, 235, 245, 0.92);
+  --aj-filter-panel-shadow:
+    0 20px 44px rgba(12, 36, 80, 0.08),
+    0 2px 10px rgba(12, 36, 80, 0.04),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+
+  --aj-filter-label-text: #456a8f;
+
+  /* Filter controls */
+  --aj-filter-control-surface:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.96),
+      rgba(250, 253, 255, 0.98)
+    ) padding-box,
+    linear-gradient(
+      135deg,
+      #dfeaf7,
+      #edf4fb
+    ) border-box;
+
+  --aj-filter-control-text: #173a62;
+  --aj-filter-control-muted: #7e93ac;
+  --aj-filter-control-shadow:
+    0 12px 24px rgba(12, 36, 80, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+
+  /* Quick filters */
+  --aj-filter-chip-bg: #f4f8ff;
+  --aj-filter-chip-text: #0b2640;
+  --aj-filter-chip-shadow: 0 8px 18px rgba(12, 36, 80, 0.1);
+
+  --aj-filter-segment-bg: #eef3fb;
+
+  /* Legacy glass tokens mapped through the theme */
+  --aj-filter-glass-bg:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.85),
+      rgba(255, 255, 255, 0.72)
+    );
+  --aj-filter-glass-border:
+    linear-gradient(
+      135deg,
+      #e7f0ff,
+      #f6f9ff
+    );
+  --aj-filter-glass-shadow:
+    0 10px 24px rgba(12, 36, 80, 0.15),
+    0 1px 0 rgba(255, 255, 255, 0.7) inset;
+
+  /* Events filter summary */
+  --aj-filter-summary-text: #173a62;
+  --aj-filter-summary-clear: #0b5ed7;
+  --aj-filter-summary-clear-hover: rgba(14, 136, 240, 0.08);
+
+  --aj-filter-summary-chip-bg:
+    linear-gradient(180deg, #ffffff, #f4f9ff);
+  --aj-filter-summary-chip-border: rgba(14, 136, 240, 0.2);
+  --aj-filter-summary-chip-border-hover: rgba(14, 136, 240, 0.38);
+  --aj-filter-summary-chip-hover: #eef7ff;
+  --aj-filter-summary-chip-text: #173a62;
+  --aj-filter-summary-chip-remove-bg: rgba(14, 136, 240, 0.1);
+
+  --aj-filter-focus-outline: rgba(14, 136, 240, 0.28);
+
+  /* Date popover */
+  --aj-date-panel-bg: rgba(255, 255, 255, 0.98);
+  --aj-date-panel-border: rgba(207, 220, 235, 0.95);
+  --aj-date-panel-shadow:
+    0 24px 48px rgba(12, 36, 80, 0.16),
+    0 4px 14px rgba(12, 36, 80, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+
+  --aj-date-text: #102840;
+  --aj-date-text-soft: #6b7f97;
+  --aj-date-border-soft: rgba(226, 235, 245, 0.96);
+
+  --aj-date-sheen:
+    linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.2),
+      rgba(255, 255, 255, 0) 24%
+    );
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --aj-theme: dark;
+
+    /* Core */
+    --aj-page-bg: #09131f;
+    --aj-surface: #101c2a;
+    --aj-surface-soft: #132131;
+    --aj-surface-elevated: #172535;
+
+    --aj-text: #f3f7fb;
+    --aj-text-strong: #f3f7fb;
+    --aj-text-secondary: #b3c2d2;
+    --aj-text-muted: #9eafc1;
+
+    --aj-border: rgba(255, 255, 255, 0.12);
+    --aj-border-strong: rgba(255, 255, 255, 0.18);
+    --aj-focus: #55b9ff;
+
+    /* Shared page surfaces */
+    --aj-surface-hover: #1a3044;
+    --aj-media-placeholder: #192b3d;
+
+    --aj-card-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+    --aj-card-shadow-hover: 0 14px 36px rgba(0, 0, 0, 0.34);
+
+    --aj-soft-control-bg: #1a2c3e;
+    --aj-soft-control-hover: #22394f;
+
+    --aj-skeleton-base: #172638;
+    --aj-skeleton-highlight: #213349;
+
+    --aj-events-hero-bg:
+      linear-gradient(120deg, #091725 0%, #10313a 100%);
+
+    --aj-home-promo-bg:
+      radial-gradient(
+        circle at 12% 24%,
+        rgba(20, 194, 197, 0.14),
+        transparent 16rem
+      ),
+      linear-gradient(
+        135deg,
+        rgba(15, 37, 52, 0.98),
+        rgba(13, 29, 43, 0.98)
+      );
+
+    --aj-home-promo-icon-bg:
+      linear-gradient(135deg, #153442, #174755);
+
+    --aj-home-promo-title: #f3f8fc;
+    --aj-home-promo-body: #bfd0dc;
+
+    --aj-home-muted-banner-bg: rgba(18, 34, 49, 0.9);
+    --aj-home-muted-banner-border: rgba(255, 255, 255, 0.12);
+
+    /* Shared content + forms */
+    --aj-accent-text: #72c5ff;
+
+    --aj-form-panel-bg: #172535;
+    --aj-form-control-bg: #132131;
+    --aj-form-control-hover: #1a3044;
+    --aj-form-control-focus: #1a2c3e;
+    --aj-form-control-text: #f3f7fb;
+    --aj-form-placeholder: #9eafc1;
+    --aj-form-border: rgba(255, 255, 255, 0.14);
+    --aj-form-border-hover: rgba(114, 197, 255, 0.34);
+
+    --aj-form-error-bg: #351c24;
+    --aj-form-error-text: #ffb4bd;
+    --aj-form-error-border: rgba(255, 107, 120, 0.35);
+
+    --aj-form-success-bg: #123126;
+    --aj-form-success-text: #9ee7c6;
+    --aj-form-success-border: rgba(95, 211, 160, 0.34);
+
+    /* About page */
+    --aj-about-hero-bg:
+      linear-gradient(120deg, #0b1724 0%, #123044 100%);
+    --aj-about-story-bg: var(--aj-page-bg);
+    --aj-about-future-bg:
+      linear-gradient(120deg, #0c1926 0%, #13283a 100%);
+    --aj-about-team-bg:
+      linear-gradient(120deg, #0d1c2a 0%, #12323a 100%);
+
+    --aj-about-heading: #72c5ff;
+    --aj-about-text: #c6d5e1;
+    --aj-about-text-neutral: #d7e2ec;
+    --aj-about-strong: #f3f7fb;
+    --aj-about-accent: #59dfe2;
+
+    --aj-about-card-bg: var(--aj-surface);
+    --aj-about-card-text: #d7e2ec;
+    --aj-about-card-secondary: var(--aj-text-secondary);
+
+    --aj-about-photo-border: #24384c;
+    --aj-about-photo-bg: var(--aj-media-placeholder);
+    --aj-about-icon-bg: var(--aj-soft-control-bg);
+
+    --aj-about-route-bg-start: #172f42;
+    --aj-about-route-bg-1: #102638;
+    --aj-about-route-bg-2: #16354a;
+
+    /* Event provider badges */
+    --aj-provider-badge-bg: rgba(114, 197, 255, 0.1);
+    --aj-provider-badge-border: rgba(114, 197, 255, 0.24);
+    --aj-provider-badge-text: #bfe2ff;
+
+    --aj-provider-smsticket-bg: rgba(124, 107, 255, 0.18);
+    --aj-provider-smsticket-border: rgba(154, 143, 255, 0.38);
+    --aj-provider-smsticket-text: #d5d0ff;
+
+    --aj-provider-ticketmaster-bg: rgba(0, 116, 224, 0.2);
+    --aj-provider-ticketmaster-border: rgba(80, 170, 255, 0.4);
+    --aj-provider-ticketmaster-text: #a8d7ff;
+
+    /* Event detail modal */
+    --aj-modal-bg: #172535;
+    --aj-modal-border: rgba(255, 255, 255, 0.14);
+    --aj-modal-shadow: 0 28px 80px rgba(0, 0, 0, 0.5);
+
+    --aj-modal-title: #f3f7fb;
+    --aj-modal-meta: #b3c2d2;
+    --aj-modal-description: #c6d2df;
+    --aj-modal-secondary: #aebdcb;
+    --aj-modal-category: #72c5ff;
+
+    --aj-modal-close-bg: #1a2c3e;
+    --aj-modal-close-text: #f3f7fb;
+    --aj-modal-image-bg: #192b3d;
+
+    --aj-modal-control-bg: #1a2c3e;
+    --aj-modal-control-hover: #22394f;
+    --aj-modal-control-border: rgba(255, 255, 255, 0.16);
+    --aj-modal-control-border-hover: rgba(114, 197, 255, 0.42);
+    --aj-modal-control-text: #eaf4ff;
+
+    /* Events announcement / TrustedStays */
+    --aj-events-info-banner-bg:
+      linear-gradient(135deg, #142536 0%, #172a3d 100%);
+    --aj-events-info-banner-border: rgba(255, 255, 255, 0.12);
+    --aj-events-info-banner-shadow: 0 12px 32px rgba(0, 0, 0, 0.24);
+    --aj-events-info-banner-text: #e8f0f7;
+    --aj-events-info-banner-accent: #0077cc;
+    --aj-events-info-banner-accent-hover: #005fad;
+
+    /* Events pagination */
+    --aj-pager-status: #9eafc1;
+    --aj-pager-button-bg: #1a2c3e;
+    --aj-pager-button-text: #f3f7fb;
+    --aj-pager-button-border: rgba(255, 255, 255, 0.14);
+    --aj-pager-button-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+    --aj-pager-button-shadow-hover: 0 12px 28px rgba(0, 0, 0, 0.28);
+    --aj-pager-primary-bg: #0b4f78;
+    --aj-pager-primary-text: #ffffff;
+    --aj-pager-primary-border: #176a98;
+
+    /* Homepage deferred */
+    --aj-home-blog-title: var(--aj-text-strong);
+    --aj-home-blog-text: var(--aj-text-secondary);
+
+    /* Shared footer */
+    --aj-footer-bg: var(--aj-surface);
+    --aj-footer-text: var(--aj-text-secondary);
+    --aj-footer-copy: var(--aj-text-secondary);
+    --aj-footer-link: #72c5ff;
+    --aj-footer-separator: var(--aj-text-muted);
+    --aj-footer-border: var(--aj-border);
+
+    /* Legacy filter compatibility */
+    --aj-filter-legacy-bg: rgba(17, 21, 32, 0.58);
+    --aj-filter-legacy-border: rgba(255, 255, 255, 0.08);
+    --aj-filter-legacy-border-2: rgba(255, 255, 255, 0.1);
+    --aj-filter-legacy-shadow:
+      0 24px 48px rgba(0, 0, 0, 0.34),
+      0 2px 8px rgba(0, 0, 0, 0.2);
+
+    --aj-filter-ink-1: #eaf0ff;
+    --aj-filter-ink-2: #d6e6ff;
+    --aj-filter-ink-3: #a6b7d7;
+
+    --aj-filter-option-bg: #0b1220;
+    --aj-filter-option-text: #e6f0ff;
+
+    --aj-filter-vendor-border: rgba(255, 255, 255, 0.1);
+    --aj-filter-vendor-outline: rgba(255, 255, 255, 0.08);
+
+    --aj-filter-typeahead-border: rgba(255, 255, 255, 0.1);
+    --aj-filter-typeahead-bg:
+      radial-gradient(
+        60% 80% at 30% 0%,
+        rgba(255, 255, 255, 0.08),
+        transparent 60%
+      ),
+      rgba(15, 23, 42, 0.72);
+    --aj-filter-typeahead-shadow:
+      0 24px 48px rgba(0, 0, 0, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    --aj-filter-typeahead-hover: rgba(255, 255, 255, 0.08);
+
+    /* Event filter shell */
+    --aj-filter-panel-bg:
+      linear-gradient(
+        180deg,
+        rgba(17, 29, 43, 0.98) 0%,
+        rgba(12, 23, 36, 0.98) 100%
+      );
+    --aj-filter-panel-border: rgba(255, 255, 255, 0.12);
+    --aj-filter-panel-shadow:
+      0 24px 48px rgba(0, 0, 0, 0.34),
+      0 2px 10px rgba(0, 0, 0, 0.22),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+    --aj-filter-label-text: #aebed0;
+
+    /* Filter controls */
+    --aj-filter-control-surface:
+      linear-gradient(
+        rgba(22, 37, 54, 0.98),
+        rgba(18, 31, 47, 0.98)
+      ) padding-box,
+      linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.18),
+        rgba(255, 255, 255, 0.08)
+      ) border-box;
+
+    --aj-filter-control-text: #f3f7fb;
+    --aj-filter-control-muted: #aebed0;
+    --aj-filter-control-shadow:
+      0 14px 28px rgba(0, 0, 0, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+
+    /* Quick filters */
+    --aj-filter-chip-bg: #17283a;
+    --aj-filter-chip-text: #eef6ff;
+    --aj-filter-chip-shadow: 0 8px 18px rgba(0, 0, 0, 0.24);
+
+    --aj-filter-segment-bg: #162536;
+
+    --aj-filter-glass-bg:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.1),
+        rgba(255, 255, 255, 0.06)
+      );
+    --aj-filter-glass-border:
+      linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.18),
+        rgba(255, 255, 255, 0.1)
+      );
+    --aj-filter-glass-shadow:
+      0 10px 24px rgba(0, 0, 0, 0.4),
+      0 1px 0 rgba(255, 255, 255, 0.06) inset;
+
+    /* Events filter summary */
+    --aj-filter-summary-text: #eef6ff;
+    --aj-filter-summary-clear: #72c5ff;
+    --aj-filter-summary-clear-hover: rgba(85, 185, 255, 0.12);
+
+    --aj-filter-summary-chip-bg:
+      linear-gradient(180deg, #17283a, #132335);
+    --aj-filter-summary-chip-border: rgba(85, 185, 255, 0.24);
+    --aj-filter-summary-chip-border-hover: rgba(85, 185, 255, 0.46);
+    --aj-filter-summary-chip-hover: #1b3045;
+    --aj-filter-summary-chip-text: #eef6ff;
+    --aj-filter-summary-chip-remove-bg: rgba(85, 185, 255, 0.14);
+
+    --aj-filter-focus-outline: rgba(85, 185, 255, 0.38);
+
+    /* Date popover */
+    --aj-date-panel-bg: rgba(14, 22, 35, 0.98);
+    --aj-date-panel-border: rgba(255, 255, 255, 0.12);
+    --aj-date-panel-shadow:
+      0 30px 60px rgba(0, 0, 0, 0.45),
+      inset 0 1px 0 rgba(255, 255, 255, 0.06);
+
+    --aj-date-text: #eef4ff;
+    --aj-date-text-soft: #aebed3;
+    --aj-date-border-soft: rgba(255, 255, 255, 0.1);
+
+    --aj-date-sheen:
+      linear-gradient(
+        180deg,
+        rgba(255, 255, 255, 0.07),
+        rgba(255, 255, 255, 0) 24%
+      );
+  }
+}

--- a/tests/provider-isolation.test.mjs
+++ b/tests/provider-isolation.test.mjs
@@ -1,0 +1,272 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test(
+  'Ticketmaster cooldown does not block SMS Ticket aggregation',
+  async () => {
+    const storage = new Map([
+      [
+        'ajsee.tm.rateLimit.v1',
+        JSON.stringify({
+          until: Date.now() + 10 * 60_000,
+          reason: 'provider_isolation_test',
+          savedAt: Date.now()
+        })
+      ]
+    ]);
+
+    const localStorage = {
+      getItem(key) {
+        return storage.has(key)
+          ? storage.get(key)
+          : null;
+      },
+
+      setItem(key, value) {
+        storage.set(
+          String(key),
+          String(value)
+        );
+      },
+
+      removeItem(key) {
+        storage.delete(key);
+      }
+    };
+
+    globalThis.window = {
+      localStorage,
+      location: {
+        hostname: 'ajsee.test',
+        search: ''
+      },
+      __ajsee: {},
+      dispatchEvent() {
+        return true;
+      }
+    };
+
+    globalThis.document = {
+      documentElement: {
+        lang: 'cs'
+      }
+    };
+
+    globalThis.location = {
+      search: ''
+    };
+
+    globalThis.CustomEvent =
+      class CustomEvent {
+        constructor(type, init = {}) {
+          this.type = type;
+          this.detail = init.detail;
+        }
+      };
+
+    let ticketmasterRequests = 0;
+    let smsticketRequests = 0;
+
+    globalThis.fetch =
+      async (input) => {
+        const url =
+          String(input);
+
+        if (
+          url.includes(
+            'ticketmasterEvents'
+          )
+        ) {
+          ticketmasterRequests += 1;
+
+          throw new Error(
+            'Ticketmaster network request must not happen during cooldown'
+          );
+        }
+
+        if (
+          url.includes(
+            '/data/smsticket-events'
+          )
+        ) {
+          smsticketRequests += 1;
+
+          return {
+            ok: true,
+
+            async json() {
+              return {
+                events: [
+                  {
+                    id:
+                      'smsticket-provider-isolation-test',
+
+                    sourceId:
+                      'provider-isolation-test',
+
+                    title: {
+                      cs:
+                        'Provider isolation test'
+                    },
+
+                    description: {
+                      cs:
+                        'Test event'
+                    },
+
+                    category:
+                      'concert',
+
+                    datetime:
+                      '2099-01-01T20:00:00',
+
+                    bookingEndsAt:
+                      '2099-01-01',
+
+                    location: {
+                      city:
+                        'Praha',
+
+                      country:
+                        'CZ',
+
+                      lat:
+                        50.0755,
+
+                      lon:
+                        14.4378
+                    },
+
+                    venue: {
+                      city:
+                        'Praha',
+
+                      name:
+                        'Test venue'
+                    },
+
+                    partner:
+                      'smsticket',
+
+                    sourceName:
+                      'SMS Ticket',
+
+                    tickets:
+                      'https://www.smsticket.cz/',
+
+                    url:
+                      'https://www.smsticket.cz/'
+                  }
+                ]
+              };
+            }
+          };
+        }
+
+        throw new Error(
+          `Unexpected fetch in provider isolation test: ${url}`
+        );
+      };
+
+    try {
+      const module =
+        await import(
+          `../src/api/eventsApi.js?provider-isolation=${Date.now()}`
+        );
+
+      const events =
+        await module.fetchEvents({
+          locale:
+            'cs',
+
+          filters: {
+            countryCode:
+              'CZ',
+
+            page:
+              0,
+
+            size:
+              12
+          }
+        });
+
+      assert.equal(
+        ticketmasterRequests,
+        0,
+        'Ticketmaster must not make a network request while cooldown is active'
+      );
+
+      assert.equal(
+        smsticketRequests,
+        1,
+        'SMS Ticket must still be loaded'
+      );
+
+      assert.ok(
+        events.length > 0,
+        'Aggregation must return events from another provider'
+      );
+
+      assert.equal(
+        events[0].partner,
+        'smsticket'
+      );
+    } finally {
+      delete globalThis.fetch;
+      delete globalThis.CustomEvent;
+      delete globalThis.location;
+      delete globalThis.document;
+      delete globalThis.window;
+    }
+  }
+);
+
+test(
+  'events page loads providers before showing Ticketmaster rate-limit fallback',
+  () => {
+    const source =
+      readFileSync(
+        new URL(
+          '../src/events-entry.js',
+          import.meta.url
+        ),
+        'utf8'
+      );
+
+    const marker =
+      source.indexOf(
+        'AJSEE_PROVIDER_ISOLATION_v1'
+      );
+
+    assert.notEqual(
+      marker,
+      -1,
+      'provider-isolation marker is missing'
+    );
+
+    const ensureLoad =
+      source.indexOf(
+        'await ensureEventsPageLoaded(locale, api, pagination.page);',
+        marker
+      );
+
+    assert.notEqual(
+      ensureLoad,
+      -1,
+      'events provider loading call is missing'
+    );
+
+    const rateLimitFallback =
+      source.indexOf(
+        "renderEventsStateMessage('rateLimit');",
+        ensureLoad
+      );
+
+    assert.ok(
+      rateLimitFallback > ensureLoad,
+      'Ticketmaster rate-limit fallback must run only after provider loading'
+    );
+  }
+);

--- a/thank-you.html
+++ b/thank-you.html
@@ -32,8 +32,18 @@
   </noscript>
 
   <style>
+    :root {
+      --thankyou-bg: #f7f7f9;
+      --thankyou-card: #ffffff;
+      --thankyou-text-strong: #192646;
+      --thankyou-text: #232c3d;
+      --thankyou-accent: #0077cc;
+      --thankyou-shadow: 0 8px 36px #002c4d1a;
+      --thankyou-focus: rgba(0, 119, 204, 0.35);
+    }
+
     body {
-      background: #f7f7f9;
+      background: var(--thankyou-bg);
       min-height: 100vh;
       margin: 0;
       display: flex;
@@ -46,9 +56,9 @@
       max-width: 430px;
       margin: 32px auto;
       padding: 2.6rem 2.3rem 2.2rem;
-      background: #fff;
+      background: var(--thankyou-card);
       border-radius: 2rem;
-      box-shadow: 0 8px 36px #002c4d1a;
+      box-shadow: var(--thankyou-shadow);
       text-align: center;
       position: relative;
       transition: box-shadow 0.2s;
@@ -72,27 +82,27 @@
       font-weight: 700;
       font-size: 1.14rem;
       letter-spacing: 0.08em;
-      color: #192646;
+      color: var(--thankyou-text-strong);
       margin-bottom: 0.2rem;
     }
 
     .thankyou-logo .motto {
       font-size: 0.95rem;
-      color: #0077cc;
+      color: var(--thankyou-accent);
       letter-spacing: 0.03em;
     }
 
     .thankyou-headline {
       font-size: 2.4rem;
       font-weight: 800;
-      color: #192646;
+      color: var(--thankyou-text-strong);
       margin: 0 0 1rem 0;
       letter-spacing: -0.02em;
     }
 
     .thankyou-message {
       font-size: 1.17rem;
-      color: #232c3d;
+      color: var(--thankyou-text);
       margin-bottom: 2.1em;
       line-height: 1.6;
       letter-spacing: -0.01em;
@@ -125,8 +135,25 @@
     }
 
     .btn-main:focus-visible {
-      outline: 3px solid rgba(0, 119, 204, 0.35);
+      outline: 3px solid var(--thankyou-focus);
       outline-offset: 4px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --thankyou-bg: #09131f;
+        --thankyou-card: #101c2a;
+        --thankyou-text-strong: #f3f7fb;
+        --thankyou-text: #b3c2d2;
+        --thankyou-accent: #72c5ff;
+        --thankyou-shadow: 0 14px 36px rgba(0, 0, 0, 0.34);
+        --thankyou-focus: rgba(85, 185, 255, 0.46);
+      }
+
+      .thankyou-logo img {
+        background: #bff4f7;
+        border-radius: 12px;
+      }
     }
 
     @media (max-width: 520px) {


### PR DESCRIPTION
## Summary

Adds automatic system-based Dark Mode across the public AJSEE website while preserving the existing Light Mode design.

Also hardens event aggregation so a Ticketmaster rate limit or outage no longer prevents independent providers such as SMS Ticket from serving events.

## Dark Mode

- adds shared semantic theme tokens
- supports automatic `prefers-color-scheme`
- preserves the existing AJSEE brand treatment
- covers Homepage and Events
- covers About, Accommodation and Partners
- covers Blog and review detail pages
- covers Microguides
- covers FAQ
- covers Privacy and Cookies
- covers Coming Soon / waitlist and confirmation pages
- covers Thank-you
- covers 404
- keeps London Musicals intentionally dark-native
- keeps the Instagram contest page outside the Dark Mode scope
- preserves existing Light Mode appearance

## Event provider resilience

- Ticketmaster rate limiting no longer aborts the full provider aggregation
- `/events` no longer short-circuits before independent providers are loaded
- SMS Ticket remains available while Ticketmaster is in cooldown
- Ticketmaster cooldown prevents unnecessary network requests
- adds provider-isolation regression tests

## QA

- Dark Mode visual QA: desktop + 390 px
- Light Mode regression QA: desktop + 390 px
- utility pages individually verified
- Homepage Ticketmaster cooldown failover: PASS
- Events Ticketmaster cooldown failover: PASS
- Event filter tests: 24/24 PASS
- Provider isolation tests: 2/2 PASS
- Full test suite after rebase: 108/108 PASS
- Production build: PASS
- `git diff --check`: PASS

## Notes

Known Sass deprecation warnings and the existing `/icons/calendar.svg` build warning are unchanged and outside the scope of this PR.