### PR TITLE
fix(events): remove legacy Ticketmaster rate-limit listener

### DIFF
--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -2108,21 +2108,6 @@ function renderEventsStateMessage(kind = 'rateLimit') {
   }
 }
 
-function bindTicketmasterRateLimitEvents() {
-  const handler = () => {
-    if (!isEventsPage() && !qs('#eventsList')) return;
-    _lastFetchSig = '';
-    resetEventsPager(eventsPager.filterSig);
-    renderEventsStateMessage('rateLimit');
-  };
-
-  [
-    'ajsee:ticketmaster-rate-limit',
-    'ajsee:ticketmaster-rate-limited',
-    'AJSEE:ticketmaster-rate-limit',
-    'AJSEE:ticketmaster-rate-limited'
-  ].forEach(type => wireOnce(window, type, handler, `tm-rate-event-${type}`));
-}
 
 /* ───────── i18n ───────── */
 function deepMerge(a = {}, b = {}) {
@@ -5027,7 +5012,6 @@ async function bootstrapMain() {
   forceInlineFilters();
   initEventsScrollGuard();
   fixHomeBlog();
-  bindTicketmasterRateLimitEvents();
 
   currentLang = getUILang();
   setLangCookie(currentLang);

--- a/tests/provider-isolation.test.mjs
+++ b/tests/provider-isolation.test.mjs
@@ -270,3 +270,41 @@ test(
     );
   }
 );
+
+test(
+  'events page does not bypass provider aggregation with a global Ticketmaster rate-limit listener',
+  () => {
+    const source =
+      readFileSync(
+        new URL(
+          '../src/events-entry.js',
+          import.meta.url
+        ),
+        'utf8'
+      );
+
+    assert.equal(
+      source.includes(
+        'bindTicketmasterRateLimitEvents'
+      ),
+      false,
+      'events page must not bind a global Ticketmaster rate-limit handler'
+    );
+
+    assert.equal(
+      source.includes(
+        'ajsee:ticketmaster-rate-limit'
+      ),
+      false,
+      'legacy Ticketmaster rate-limit event listener must stay removed'
+    );
+
+    assert.equal(
+      source.includes(
+        'AJSEE:ticketmaster-rate-limit'
+      ),
+      false,
+      'legacy Ticketmaster rate-limit event listener must stay removed'
+    );
+  }
+);


### PR DESCRIPTION
## Summary

Removes the obsolete global Ticketmaster rate-limit event listener from the Events page.

The listener used legacy event names that are no longer emitted. More importantly, reconnecting it would allow a Ticketmaster rate-limit event to bypass provider aggregation and replace valid results from independent providers such as SMS Ticket with a global paused state.

## Changes

- removes `bindTicketmasterRateLimitEvents()`
- removes its bootstrap registration
- keeps rate-limit handling based on Ticketmaster state + provider aggregation result
- adds a regression test preventing the legacy global listener from returning

## QA

- Event filter tests: 24/24 PASS
- Provider isolation tests: 3/3 PASS
- Full test suite: 108/108 PASS
- Production build: PASS
- `git diff --check`: PASS