### PR TITLE
fix(theme): complete dark mode for interactive overlays

### DIFF
--- a/src/styles/partials/_date-popover.scss
+++ b/src/styles/partials/_date-popover.scss
@@ -1099,3 +1099,155 @@ body.ajsee-date-sheet-open {
     min-width: 66px;
   }
 }
+
+/* AJSEE_DARK_DATE_POPOVER_V1 */
+@media (prefers-color-scheme: dark) {
+  .ajsee-date-popover__backdrop {
+    background: rgba(2, 8, 16, 0.68);
+  }
+
+  .ajsee-date-popover__surface {
+    color: var(--ajsee-date-ink);
+    background:
+      radial-gradient(
+        circle at top left,
+        rgba(20, 194, 197, 0.08),
+        transparent 28%
+      ),
+      radial-gradient(
+        circle at top right,
+        rgba(14, 136, 240, 0.12),
+        transparent 32%
+      ),
+      var(--ajsee-date-panel-bg);
+
+    border-color: var(--ajsee-date-panel-brd);
+    box-shadow: var(--ajsee-date-panel-shadow);
+  }
+
+  .ajsee-date-popover__surface::before {
+    background: var(--aj-date-sheen);
+  }
+
+  .ajsee-date-popover__grab {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .ajsee-date-popover__close,
+  .ajsee-date-popover__nav,
+  .ajsee-date-popover__btn--ghost {
+    color: var(--ajsee-date-ink);
+    background: var(--aj-surface-soft);
+    border-color: var(--ajsee-date-border-soft);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  .ajsee-date-popover__close:hover,
+  .ajsee-date-popover__close:focus-visible,
+  .ajsee-date-popover__nav:hover,
+  .ajsee-date-popover__nav:focus-visible,
+  .ajsee-date-popover__btn--ghost:hover,
+  .ajsee-date-popover__btn--ghost:focus-visible {
+    color: var(--ajsee-date-ink);
+    background: var(--aj-surface-hover);
+  }
+
+  .ajsee-date-popover__close:focus-visible,
+  .ajsee-date-popover__nav:focus-visible,
+  .ajsee-date-popover__btn:focus-visible {
+    outline: 2px solid var(--aj-focus);
+    outline-offset: 2px;
+  }
+
+  .ajsee-date-popover__field input {
+    color-scheme: dark;
+    color: var(--ajsee-date-ink);
+    background: var(--aj-surface-soft);
+    border-color: var(--ajsee-date-border-soft);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  .ajsee-date-popover__field input:focus {
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-focus);
+    outline: none;
+    box-shadow:
+      0 0 0 4px rgba(85, 185, 255, 0.16);
+  }
+
+  .ajsee-date-popover__day {
+    color: var(--ajsee-date-ink);
+    background: rgba(255, 255, 255, 0.045);
+    border-color: var(--ajsee-date-border-soft);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.035);
+  }
+
+  .ajsee-date-popover__day:hover {
+    color: var(--ajsee-date-ink);
+    background: var(--aj-surface-hover);
+    border-color: rgba(85, 185, 255, 0.24);
+    box-shadow: none;
+  }
+
+  .ajsee-date-popover__day:focus-visible {
+    outline: 2px solid var(--aj-focus);
+    outline-offset: 2px;
+  }
+
+  .ajsee-date-popover__day.is-disabled {
+    background: transparent;
+    border-color: transparent;
+  }
+
+  .ajsee-date-popover__day.is-in-range {
+    color: var(--ajsee-date-ink);
+    background: rgba(85, 185, 255, 0.16);
+    border-color: rgba(85, 185, 255, 0.28);
+  }
+
+  .ajsee-date-popover__day.is-start,
+  .ajsee-date-popover__day.is-end {
+    color: #fff;
+    background:
+      linear-gradient(
+        180deg,
+        var(--ajsee-date-accent),
+        var(--ajsee-date-accent-strong)
+      );
+
+    border-color: transparent;
+    box-shadow:
+      0 12px 22px rgba(14, 136, 240, 0.22),
+      inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  }
+
+  .ajsee-date-popover__actions {
+    color: var(--ajsee-date-ink);
+    background:
+      color-mix(
+        in oklab,
+        var(--ajsee-date-panel-bg) 92%,
+        transparent
+      );
+
+    border-top-color: var(--ajsee-date-border-soft);
+  }
+
+  .ajsee-date-popover__btn {
+    color: var(--ajsee-date-ink);
+  }
+
+  .ajsee-date-popover__btn--primary {
+    color: #fff;
+    border-color: transparent;
+    background:
+      linear-gradient(
+        180deg,
+        var(--ajsee-date-accent),
+        var(--ajsee-date-accent-strong)
+      );
+  }
+}

--- a/src/styles/partials/filters-premium.scss
+++ b/src/styles/partials/filters-premium.scss
@@ -1644,3 +1644,23 @@ body[data-page="events"] #events-city-filter[data-autofromnearme="1"] {
     font-size: 13px;
   }
 }
+
+/* AJSEE_DARK_FILTER_CONTROLS_V2 */
+@media (prefers-color-scheme: dark) {
+  :where(.events-filters.filter-dock, form.filter-dock) input[type="date"] {
+    color-scheme: dark;
+  }
+
+  :where(.events-filters.filter-dock, form.filter-dock) input.styled-input:focus,
+  :where(.events-filters.filter-dock, form.filter-dock) select.styled-select:focus,
+  :where(.events-filters.filter-dock, form.filter-dock) input[type="date"]:focus,
+  :where(.events-filters.filter-dock, form.filter-dock) input[type="search"]:focus,
+  :where(.events-filters.filter-dock, form.filter-dock) input[type="text"]:focus {
+    color: var(--aj-filter-control-text);
+    background: var(--aj-filter-control-surface);
+    border-color: transparent;
+    box-shadow:
+      0 0 0 6px var(--aj-filter-focus-outline),
+      var(--aj-filter-control-shadow);
+  }
+}

--- a/src/styles/partials/header.scss
+++ b/src/styles/partials/header.scss
@@ -570,3 +570,124 @@
     box-shadow: none;
   }
 }
+
+/* AJSEE_DARK_INTERACTIVE_NAV_V1 */
+@media (prefers-color-scheme: dark) and (max-width: 950px) {
+  .hamburger-btn {
+    color: var(--aj-focus);
+  }
+
+  .hamburger-btn span {
+    background: var(--aj-focus);
+  }
+
+  .site-header .menu-overlay-bg {
+    background: rgba(2, 8, 16, 0.62);
+  }
+
+  .site-header .main-nav {
+    background:
+      radial-gradient(
+        circle at 100% 0%,
+        rgba(14, 136, 240, 0.2),
+        transparent 38%
+      ),
+      radial-gradient(
+        circle at 10% 100%,
+        rgba(20, 194, 197, 0.1),
+        transparent 42%
+      ),
+      linear-gradient(
+        160deg,
+        var(--aj-surface-elevated) 0%,
+        var(--aj-surface) 58%,
+        #0b2434 100%
+      );
+
+    color: var(--aj-text);
+    border-left: 1px solid var(--aj-border);
+    box-shadow: -24px 0 60px rgba(0, 0, 0, 0.42);
+  }
+
+  .site-header .main-nav a {
+    color: var(--aj-text);
+  }
+
+  .site-header .main-nav a:hover,
+  .site-header .main-nav a:focus-visible {
+    color: var(--aj-text-strong);
+    background: var(--aj-surface-hover);
+  }
+
+  .site-header .main-nav a[aria-current="page"],
+  .site-header .main-nav a.active {
+    color: #72c5ff;
+  }
+
+  .site-header .language-switcher.mobile-switcher .lang-current {
+    color: var(--aj-text-strong);
+    background: rgba(255, 255, 255, 0.055);
+    border-color: rgba(255, 255, 255, 0.18);
+    box-shadow:
+      0 12px 28px rgba(0, 0, 0, 0.22),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  }
+
+  .site-header .language-switcher.mobile-switcher .lang-current:hover,
+  .site-header .language-switcher.mobile-switcher .lang-current:focus-visible {
+    color: #fff;
+    background: var(--aj-surface-hover);
+    border-color: rgba(85, 185, 255, 0.42);
+  }
+
+  .site-header .language-switcher.mobile-switcher .lang-current:focus-visible {
+    outline: 2px solid var(--aj-focus);
+    outline-offset: 3px;
+  }
+
+  .site-header .language-switcher.mobile-switcher .lang-current-label {
+    color: inherit;
+    opacity: 1;
+  }
+
+  .site-header .language-switcher.mobile-switcher .lang-caret {
+    color: #72c5ff;
+    opacity: 1;
+  }
+
+  .site-header .language-switcher.mobile-switcher .lang-dropdown[open] .lang-current {
+    color: #fff;
+    background: var(--aj-surface-hover);
+    border-color: rgba(85, 185, 255, 0.42);
+  }
+
+  .site-header .language-switcher.mobile-switcher .lang-menu {
+    color: var(--aj-text);
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-border);
+    box-shadow:
+      0 22px 48px rgba(0, 0, 0, 0.38),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  }
+
+  .site-header .lang-btn {
+    color: var(--aj-text);
+  }
+
+  .site-header .lang-btn:hover,
+  .site-header .lang-btn:focus-visible {
+    color: var(--aj-text-strong);
+    background: var(--aj-surface-hover);
+  }
+
+  .site-header .menu-close {
+    color: var(--aj-text);
+    background: rgba(255, 255, 255, 0.07);
+    border-color: var(--aj-border);
+  }
+
+  .site-header .menu-close:hover,
+  .site-header .menu-close:focus-visible {
+    background: var(--aj-surface-hover);
+  }
+}

--- a/src/styles/partials/typeahead.scss
+++ b/src/styles/partials/typeahead.scss
@@ -483,3 +483,208 @@ body.city-picker-open {
     display: none !important;
   }
 }
+
+/* AJSEE_DARK_CITY_PICKER_V1 */
+@media (prefers-color-scheme: dark) {
+  html body .ta-popover,
+  html body .typeahead-panel {
+    color: var(--aj-text);
+    background: var(--aj-filter-typeahead-bg);
+    border-color: var(--aj-filter-typeahead-border);
+    box-shadow: var(--aj-filter-typeahead-shadow);
+  }
+
+  html body .typeahead-section-title,
+  html body .typeahead-loading,
+  html body .typeahead-empty {
+    color: var(--aj-text-secondary);
+  }
+
+  html body .ta-popover .ta-item,
+  html body .typeahead-item {
+    color: var(--aj-text);
+    border-color: transparent;
+    border-top-color: rgba(255, 255, 255, 0.07);
+  }
+
+  html body .ta-popover .ta-item span,
+  html body .typeahead-item .ti-city,
+  html body .ti-city {
+    color: var(--aj-text-strong);
+  }
+
+  html body .typeahead-item .ti-meta,
+  html body .typeahead-item .ti-sub,
+  html body .ti-meta,
+  html body .ti-sub {
+    color: var(--aj-text-secondary);
+  }
+
+  html body .ta-popover .ta-item:hover,
+  html body .ta-popover .ta-item.active,
+  html body .typeahead-item:hover,
+  html body .typeahead-item.active {
+    color: var(--aj-text);
+    background: var(--aj-filter-typeahead-hover);
+    border-color: rgba(85, 185, 255, 0.24);
+    box-shadow: none;
+  }
+
+  html body .ta-popover .ta-item.active .ti-city,
+  html body .typeahead-item.active .ti-city {
+    color: #72c5ff;
+  }
+
+  html body .ta-popover .ta-item.nearme,
+  html body .typeahead-item.nearme {
+    background:
+      linear-gradient(
+        135deg,
+        rgba(20, 194, 197, 0.12),
+        rgba(14, 136, 240, 0.12)
+      );
+  }
+
+  html body .ta-popover .ta-item.nearme:hover,
+  html body .ta-popover .ta-item.nearme.active,
+  html body .typeahead-item.nearme:hover,
+  html body .typeahead-item.nearme.active {
+    background:
+      linear-gradient(
+        135deg,
+        rgba(20, 194, 197, 0.2),
+        rgba(14, 136, 240, 0.2)
+      );
+  }
+
+  html body .typeahead-item.nearme .ti-city {
+    color: #72c5ff;
+  }
+
+  html body .ta-popover mark,
+  html body .typeahead-item mark,
+  html body .ti-city mark,
+  html body .city-sheet__option-city mark {
+    background: rgba(85, 185, 255, 0.18);
+    color: inherit;
+  }
+
+  html body .city-sheet-backdrop {
+    background: rgba(2, 8, 16, 0.68);
+  }
+
+  html body .city-sheet {
+    color: var(--aj-text);
+    background:
+      radial-gradient(
+        circle at 100% 0%,
+        rgba(14, 136, 240, 0.12),
+        transparent 32%
+      ),
+      linear-gradient(
+        180deg,
+        var(--aj-surface-elevated) 0%,
+        var(--aj-surface) 100%
+      );
+
+    border-color: var(--aj-border);
+    box-shadow:
+      0 -26px 64px rgba(0, 0, 0, 0.48),
+      inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  }
+
+  html body .city-sheet__grab {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  html body .city-sheet__title {
+    color: var(--aj-text-strong);
+  }
+
+  html body .city-sheet__subtitle,
+  html body .city-sheet__section-title,
+  html body .city-sheet__hint,
+  html body .city-sheet__state {
+    color: var(--aj-text-secondary);
+  }
+
+  html body .city-sheet__close {
+    color: var(--aj-text);
+    background: var(--aj-surface-soft);
+    border-color: var(--aj-border);
+    box-shadow: none;
+  }
+
+  html body .city-sheet__close:hover,
+  html body .city-sheet__close:focus-visible {
+    background: var(--aj-surface-hover);
+    outline: 2px solid var(--aj-focus);
+    outline-offset: 2px;
+  }
+
+  html body .city-sheet__search {
+    color-scheme: dark;
+    color: var(--aj-text);
+    background: var(--aj-surface-soft);
+    border-color: var(--aj-border);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  }
+
+  html body .city-sheet__search::placeholder {
+    color: var(--aj-text-secondary);
+  }
+
+  html body .city-sheet__search:focus {
+    color: var(--aj-text);
+    background: var(--aj-surface-elevated);
+    border-color: var(--aj-focus);
+    box-shadow:
+      0 0 0 4px rgba(85, 185, 255, 0.18);
+  }
+
+  html body .city-sheet__nearme {
+    background:
+      linear-gradient(
+        135deg,
+        rgba(20, 194, 197, 0.12),
+        rgba(14, 136, 240, 0.13)
+      );
+
+    border-color: rgba(85, 185, 255, 0.3);
+    box-shadow: none;
+  }
+
+  html body .city-sheet__nearme-title {
+    color: #72c5ff;
+  }
+
+  html body .city-sheet__nearme-sub {
+    color: var(--aj-text-secondary);
+  }
+
+  html body .city-sheet__option {
+    color: var(--aj-text);
+    background: rgba(255, 255, 255, 0.035);
+    border-color: transparent;
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.035);
+  }
+
+  html body .city-sheet__option:hover,
+  html body .city-sheet__option:focus-visible {
+    color: var(--aj-text);
+    background: var(--aj-surface-hover);
+    border-color: rgba(85, 185, 255, 0.28);
+    box-shadow: none;
+    outline: none;
+  }
+
+  html body .city-sheet__option-city {
+    color: var(--aj-text-strong);
+  }
+
+  html body .city-sheet__option-meta {
+    color: var(--aj-text-secondary);
+  }
+}


### PR DESCRIPTION
## Summary
- add dark mode styling for the mobile hamburger menu and language switcher
- add dark mode styling for desktop and mobile city picker/typeahead
- add dark mode styling for date filter controls and custom date popover
- preserve existing light mode appearance and behavior

## QA
- test suite: 108/108 ✅
- production build ✅
- hamburger + language switcher dark mode ✅
- mobile city picker dark mode ✅
- date picker / calendar dark mode ✅
- light mode regression check ✅