### PR TITLE
fix(city-picker): improve mobile city selection UX

### DIFF
--- a/src/city/typeahead.js
+++ b/src/city/typeahead.js
@@ -1086,7 +1086,7 @@ export function setupCityTypeahead(inputEl, opts = {}) {
     backdrop.hidden = true;
 
     backdrop.innerHTML = `
-      <div class="city-sheet" role="dialog" aria-modal="true" aria-labelledby="city-sheet-title-${uid}">
+      <div class="city-sheet" role="dialog" aria-modal="true" aria-labelledby="city-sheet-title-${uid}" tabindex="-1">
         <div class="city-sheet__grab" aria-hidden="true"></div>
 
         <div class="city-sheet__header">
@@ -1335,11 +1335,12 @@ export function setupCityTypeahead(inputEl, opts = {}) {
     loading = false;
     renderMobile();
 
+    // AJSEE_MOBILE_CITY_PICKER_NO_AUTO_KEYBOARD_V1
+    // Keep focus inside the modal without opening the software keyboard.
+    // The search field receives focus only after an explicit user interaction.
     setTimeout(() => {
       try {
-        sheetSearch.focus({ preventScroll: true });
-        const len = sheetSearch.value.length;
-        sheetSearch.setSelectionRange(len, len);
+        sheet.focus({ preventScroll: true });
       } catch {}
     }, 40);
   }

--- a/src/events-entry.js
+++ b/src/events-entry.js
@@ -3839,23 +3839,18 @@ function syncCitySheetUsability(root = document) {
   const search = root.querySelector('.city-sheet__search');
   if (search) {
     const placeholder = getCitySearchPlaceholder();
-    if (search.getAttribute('placeholder') !== placeholder) search.setAttribute('placeholder', placeholder);
+
+    if (search.getAttribute('placeholder') !== placeholder) {
+      search.setAttribute('placeholder', placeholder);
+    }
   }
 
-  const content = root.querySelector('.city-sheet__content');
-  if (content) {
-    content.style.overflowY = 'auto';
-    content.style.overflowX = 'hidden';
-    content.style.webkitOverflowScrolling = 'touch';
-    content.style.overscrollBehavior = 'contain';
-    content.style.touchAction = 'pan-y';
-  }
-
-  const results = root.querySelector('.city-sheet__results');
-  if (results) {
-    results.style.minHeight = '1px';
-    results.style.paddingBottom = 'max(16px, env(safe-area-inset-bottom, 0px))';
-  }
+  /*
+   * AJSEE_EVENTS_CITY_SHEET_SHARED_LAYOUT_V1
+   * Layout, scrolling and safe-area behaviour belong to the shared
+   * city picker component. Do not override them with inline styles
+   * from the Events page.
+   */
 }
 
 function installCitySheetObserver() {
@@ -3868,7 +3863,7 @@ function installCitySheetObserver() {
     childList: true,
     subtree: true,
     attributes: true,
-    attributeFilter: ['class', 'hidden', 'style']
+    attributeFilter: ['class', 'hidden']
   });
 
   G.state._citySheetMO = mo;

--- a/src/styles/partials/typeahead.scss
+++ b/src/styles/partials/typeahead.scss
@@ -688,3 +688,159 @@ body.city-picker-open {
     color: var(--aj-text-secondary);
   }
 }
+
+/* AJSEE_MOBILE_CITY_PICKER_UX_V1 */
+@media (max-width: 720px) {
+  html body .city-sheet {
+    gap: 0.7rem;
+    padding:
+      0.65rem
+      1rem
+      calc(1rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  html body .city-sheet__grab {
+    width: 44px;
+    height: 4px;
+    margin: 0.1rem auto 0.25rem;
+  }
+
+  html body .city-sheet__header {
+    gap: 0.75rem;
+    padding: 0;
+    margin: 0;
+    align-items: center;
+  }
+
+  html body .city-sheet__title {
+    font-size: 1.35rem;
+    line-height: 1.12;
+  }
+
+  /*
+   * The search placeholder already explains the interaction.
+   * Removing the mobile subtitle gives the primary choices
+   * substantially more room above the fold.
+   */
+  html body .city-sheet__subtitle {
+    display: none;
+  }
+
+  html body .city-sheet__close {
+    width: 44px;
+    height: 44px;
+    flex: 0 0 44px;
+  }
+
+  html body .city-sheet__search-wrap {
+    margin: 0;
+    padding: 0;
+  }
+
+  html body .city-sheet__search {
+    height: 54px;
+    min-height: 54px;
+    padding: 0 0.9rem;
+    border-radius: 16px;
+    font-size: 1rem;
+  }
+
+  html body .city-sheet__content {
+    min-height: 0;
+    gap: 0.65rem;
+    padding:
+      0
+      0
+      calc(0.25rem + env(safe-area-inset-bottom, 0px));
+    overflow: hidden;
+  }
+
+  html body .city-sheet__nearme {
+    min-height: 58px;
+    padding: 0.7rem 0.85rem;
+    margin: 0;
+    gap: 0.12rem;
+    border-radius: 16px;
+    box-shadow: none;
+  }
+
+  html body .city-sheet__nearme-title {
+    font-size: 0.98rem;
+  }
+
+  html body .city-sheet__nearme-sub {
+    font-size: 0.8rem;
+  }
+
+  html body .city-sheet__section-title {
+    margin: 0.15rem 0 0;
+    padding: 0 0.1rem;
+    font-size: 0.75rem;
+  }
+
+  /*
+   * Browsing state:
+   * popular/favourite cities are fast choices, so use a dense
+   * two-column grid instead of a long one-card-per-row feed.
+   */
+  html body
+    .city-sheet__content:not(.is-searching)
+    .city-sheet__results {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-rows: minmax(60px, auto);
+    gap: 0.5rem;
+    align-content: start;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 0 0 0.25rem;
+  }
+
+  html body
+    .city-sheet__content:not(.is-searching)
+    .city-sheet__option {
+    width: 100%;
+    min-width: 0;
+    min-height: 60px;
+    justify-content: center;
+    padding: 0.65rem 0.75rem;
+    gap: 0.08rem;
+    border-radius: 14px;
+  }
+
+  html body
+    .city-sheet__content:not(.is-searching)
+    .city-sheet__option-city {
+    font-size: 0.98rem;
+    line-height: 1.2;
+  }
+
+  html body
+    .city-sheet__content:not(.is-searching)
+    .city-sheet__option-meta {
+    font-size: 0.74rem;
+    line-height: 1.2;
+  }
+
+  /*
+   * Search state:
+   * suggestions need more room for names and metadata,
+   * so switch back to the conventional one-column list.
+   */
+  html body
+    .city-sheet__content.is-searching
+    .city-sheet__results {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  html body
+    .city-sheet__content.is-searching
+    .city-sheet__option {
+    min-height: 54px;
+    padding: 0.65rem 0.35rem;
+  }
+}


### PR DESCRIPTION
## Summary
- modernize the mobile city picker without changing the desktop dropdown
- show favourite cities in a denser two-column grid
- keep search results in a compact one-column list
- reduce vertical spacing to expose more cities above the fold
- stop auto-focusing the search field on open to avoid immediately showing the mobile keyboard
- keep focus inside the modal for accessibility

## QA
- production build ✅
- mobile city picker layout ✅
- favourite cities visible in two columns ✅
- no automatic keyboard on open ✅
- desktop city picker unchanged ✅