### PR TITLE
fix(review): separate markdown headings from paragraphs

### DIFF
--- a/scripts/build-review-details.mjs
+++ b/scripts/build-review-details.mjs
@@ -243,9 +243,45 @@ function markdownToHtml(markdown = '') {
 
   if (!text) return '';
 
+  /*
+   * ATX headings are block elements even when the source does
+   * not contain an empty line after them. Split heading lines
+   * into standalone blocks before rendering paragraphs/lists.
+   */
   const blocks = text
     .split(/\n{2,}/)
-    .map((block) => block.trim())
+    .flatMap((block) => {
+      const parts = [];
+      let pending = [];
+
+      const flushPending = () => {
+        const value = pending
+          .join('\n')
+          .trim();
+
+        if (value) {
+          parts.push(value);
+        }
+
+        pending = [];
+      };
+
+      for (const rawLine of block.split('\n')) {
+        const line = rawLine.trim();
+
+        if (/^#{1,3}\s+/.test(line)) {
+          flushPending();
+          parts.push(line);
+          continue;
+        }
+
+        pending.push(rawLine);
+      }
+
+      flushPending();
+
+      return parts;
+    })
     .filter(Boolean);
 
   return blocks

--- a/tests/review-inline-markdown.test.mjs
+++ b/tests/review-inline-markdown.test.mjs
@@ -270,5 +270,48 @@ test(
       lesMisContent,
       /\*\*Les Misérables: The Arena Spectacular\*\*/
     );
+
+    /*
+     * Block-renderer regression:
+     * ATX headings must remain standalone block elements even
+     * when the following paragraph starts on the next line.
+     */
+    const westEndPath = path.join(
+      ROOT,
+      "review-preview",
+      "10-west-end-musicals-worth-travelling-to-london-for",
+      "index.html"
+    );
+
+    const westEndHtml =
+      await readFile(
+        westEndPath,
+        "utf8"
+      );
+
+    const westEndContent =
+      visibleReviewContent(
+        westEndHtml
+      );
+
+    assert.match(
+      westEndContent,
+      /<h3>1\. Les Misérables<\/h3>\s*<p>Pokud existuje jeden muzikál/
+    );
+
+    assert.doesNotMatch(
+      westEndContent,
+      /<h3>1\. Les Misérables\s+Pokud existuje jeden muzikál/
+    );
+
+    assert.match(
+      westEndContent,
+      /<h2>Proč právě Londýn\?<\/h2>\s*<p>Lidé se často ptají/
+    );
+
+    assert.match(
+      westEndContent,
+      /<h2>Závěrečná opona<\/h2>\s*<p>Pokaždé, když navštívím/
+    );
   }
 );


### PR DESCRIPTION
## Summary

Fixes review Markdown rendering when an ATX heading is immediately followed by a paragraph without an empty line.

Previously:

```markdown
### 1. Les Misérables
Paragraph text